### PR TITLE
Add more options to configure the progressbar

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -318,8 +318,11 @@
 #centered_cursor = no
 #
 ##
-## Note: You can specify third character which will be used to build 'empty'
-## part of progressbar.
+## Note: You can specify up to 5 characters here:
+## given the config
+## progressbar_look = 12345
+## the progressbar would look like this:
+## 122222344444444444444445
 ##
 #progressbar_look = =>
 #

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -219,7 +219,7 @@ Default state for autocenter mode at start.
 If enabled, currently highlighted position in the list will be always centered.
 .TP
 .B progressbar_look = TEXT
-This variable defines the look of progressbar. Note that it has to be exactly two or three characters long.
+This variable defines the look of progressbar. Note that it has to be between two and five characters long.
 .TP
 .B default_place_to_search_in = database/playlist
 If set to "playlist", Search engine will perform searching in current MPD playlist rather than in music database.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -415,9 +415,9 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("centered_cursor", &centered_cursor, "no", yes_no);
 	p.add("progressbar_look", &progressbar, "=>", [](std::string v) {
 			auto result = ToWString(std::move(v));
-			boundsCheck<std::wstring::size_type>(result.size(), 2, 3);
-			// If two characters were specified, fill \0 as the third one.
-			result.resize(3);
+			boundsCheck<std::wstring::size_type>(result.size(), 2, 5);
+			// If less than 5 characters were specified, fill \0 as the remaining.
+			result.resize(5);
 			return result;
 	});
 	p.add("default_place_to_search_in", &search_in_db, "database", [](std::string v) {

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -60,24 +60,51 @@ void Progressbar::draw(unsigned int elapsed, unsigned int time)
 	unsigned pb_width = wFooter->getWidth();
 	unsigned howlong = time ? pb_width*elapsed/time : 0;
 	*wFooter << Config.progressbar_color;
-	if (Config.progressbar[2] != '\0')
+
+	// set the different bar characters depending on the amount of configured chars
+	char bar_start_char = Config.progressbar[0];
+	char bar_time_char = Config.progressbar[0];
+	char bar_time_end_char = Config.progressbar[1];
+	char bar_remaining_char = Config.progressbar[2];
+	char bar_remaining_end_char = Config.progressbar[2];
+	if (Config.progressbar[3] != '\0') 
 	{
-		wFooter->goToXY(0, 0);
-		for (unsigned i = 0; i < pb_width; ++i)
-			*wFooter << Config.progressbar[2];
-		wFooter->goToXY(0, 0);
+		bar_time_char = Config.progressbar[1];
+		bar_remaining_char = Config.progressbar[2];
+		bar_time_end_char = Config.progressbar[3];
+		bar_remaining_end_char = Config.progressbar[3];
+	} 
+	if (Config.progressbar[4] != '\0') 
+	{
+		bar_remaining_end_char = Config.progressbar[4];
+	}
+
+
+	// draw the progressbar
+	if (Config.progressbar[2] == '\0')
+	{
+		mvwhline(wFooter->raw(), 0, 0, 0, pb_width);
 	}
 	else
-		mvwhline(wFooter->raw(), 0, 0, 0, pb_width);
+	{
+		wFooter->goToXY(0, 0);
+		*wFooter << bar_start_char;
+		for (unsigned i = 1; i < pb_width - 1; ++i) {
+			*wFooter << bar_remaining_char;
+		}
+		*wFooter << bar_remaining_end_char;
+		wFooter->goToXY(0, 0);
+	}
 	*wFooter << NC::FormattedColor::End<>(Config.progressbar_color);
 	if (time)
 	{
 		*wFooter << Config.progressbar_elapsed_color;
 		pb_width = std::min(size_t(howlong), wFooter->getWidth());
-		for (unsigned i = 0; i < pb_width; ++i)
-			*wFooter << Config.progressbar[0];
+		*wFooter << bar_start_char;
+		for (unsigned i = 1; i < pb_width; ++i)
+			*wFooter << bar_time_char;
 		if (howlong < wFooter->getWidth())
-			*wFooter << Config.progressbar[1];
+			*wFooter << bar_time_end_char;
 		*wFooter << NC::FormattedColor::End<>(Config.progressbar_elapsed_color);
 	}
 }


### PR DESCRIPTION
This PR adds the option to configure up to 5 different characters for the progressbar.
This allows users to for example use powerline-fonts to theme their progress bar.

The characters provided are:
- start of progressbar
- body of elapsed part
- separator
- body of remaining part
- end of progressbar.
