### PR TITLE
configuration: add mpd_password option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,3 +46,4 @@ Trygve Aaberge <trygveaa@gmail.com>
 Wieland Hoffmann <themineo@gmail.com>
 Wojciech Siewierski <wojciech.siewierski@onet.pl>
 Yannick LM <yannicklm1337@gmail.com>
+V <v@anomalous.eu>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # ncmpcpp-0.10 (????-??-??)
+* Add the configuration option `mpd_password`.
 
 # ncmpcpp-0.9.2 (2021-01-24)
 * Revert suppression of output of all external commands as that makes e.g album

--- a/doc/config
+++ b/doc/config
@@ -27,6 +27,8 @@
 #
 #mpd_port = 6600
 #
+#mpd_password = ""
+#
 #mpd_connection_timeout = 5
 #
 ## Needed for tag editor and file operations to work.

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -74,6 +74,9 @@ Connect to MPD running on specified host/unix socket. When HOST starts with a '/
 .B mpd_port = PORT
 Connect to MPD on the specified port. Note: MPD_PORT environment variable overrides this setting.
 .TP
+.B mpd_password = PASSWORD
+Use PASSWORD to authenticate to MPD.
+.TP
 .B mpd_music_dir = PATH
 Search for files in specified directory. This is needed for tag editor to work.
 .TP

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -244,6 +244,10 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add<void>("mpd_port", nullptr, "6600", [](std::string port) {
 			Mpd.SetPort(verbose_lexical_cast<unsigned>(port));
 		});
+	p.add<void>("mpd_password", nullptr, "", [](std::string password) {
+			if (!password.empty())
+				Mpd.SetPassword(password);
+		});
 	p.add("mpd_music_dir", &mpd_music_dir, "~/music", adjust_directory);
 	p.add("mpd_connection_timeout", &mpd_connection_timeout, "5");
 	p.add("mpd_crossfade_time", &crossfade_time, "5");


### PR DESCRIPTION
Although this can already be set via mpd_host, having a separate option
is cleaner, and doesn't require setting the host when ncmpcpp already
detects it correctly.