### PR TITLE
Add an explicit playlist Load action

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1034,6 +1034,27 @@ void Add::run()
 	}
 }
 
+bool Load::canBeRun()
+{
+	return myScreen != myPlaylistEditor;
+}
+
+void Load::run()
+{
+	using Global::wFooter;
+
+	std::string path;
+	{
+		Statusbar::ScopedLock slock;
+		Statusbar::put() << "Load playlist: ";
+		path = wFooter->prompt();
+	}
+
+	Statusbar::put() << "Loading...";
+	wFooter->refresh();
+	Mpd.LoadPlaylist(path);
+}
+
 bool SeekForward::canBeRun()
 {
 	return Status::State::player() != MPD::psStop && Status::State::totalTime() > 0;
@@ -2753,6 +2774,7 @@ void populateActions()
 	insert_action(new Actions::MoveSelectedItemsDown());
 	insert_action(new Actions::MoveSelectedItemsTo());
 	insert_action(new Actions::Add());
+	insert_action(new Actions::Load());
 	insert_action(new Actions::PlayItem());
 	insert_action(new Actions::SeekForward());
 	insert_action(new Actions::SeekBackward());

--- a/src/actions.h
+++ b/src/actions.h
@@ -77,6 +77,7 @@ enum class Type
 	MoveSelectedItemsDown,
 	MoveSelectedItemsTo,
 	Add,
+	Load,
 	SeekForward,
 	SeekBackward,
 	ToggleDisplayMode,
@@ -600,6 +601,15 @@ private:
 struct Add: BaseAction
 {
 	Add(): BaseAction(Type::Add, "add") { }
+	
+private:
+	virtual bool canBeRun() override;
+	virtual void run() override;
+};
+
+struct Load: BaseAction
+{
+	Load(): BaseAction(Type::Load, "load") { }
 	
 private:
 	virtual bool canBeRun() override;


### PR DESCRIPTION
The `Add` command only falls back to a playlist load if mpd returns a specific error code for the add command. This is currently the only way to load a playlist via ncmpcpp and is suboptimal for a few reasons. It also gets in the way when mpd playlist and input plugins exist that handle the same URL scheme. mpd's maintainer has [previously commented on this behaviour](https://github.com/MusicPlayerDaemon/MPD/pull/223#discussion_r168917342), calling it:
> funny assumptions on something that's not explicitly documented in the protocol spec (and yes, the protocol spec isn't very specific on some things, and needs to improve).

This PR adds an explicit playlist load command to be used when the user wants to add a playlist instead. Note that this PR does not include a default keybinding for the action, and does not change the existing fallback behaviour for the add command.