### PR TITLE
Fix delete key in st

### DIFF
--- a/src/curses/window.cpp
+++ b/src/curses/window.cpp
@@ -948,6 +948,8 @@ Key::Type Window::getInputChar(int key)
 			m_mouse_event.y = (raw_y - 33) & 0xff;
 			return define_mouse_event(key);
 		}
+		case 'P': // st
+			return Key::Delete;
 		case 'Z':
 			return Key::Shift | Key::Tab;
 		case '[': // F1 to F5 in tty


### PR DESCRIPTION
There is a bug where the delete key doesn't work in [st](https://st.suckless.org/). This is because of an escape sequence it uses to delete, namely ^[[P. This PR simply adds that escape sequence to the list of escape sequences.
fixes #424