### PR TITLE
Update Makefile to reflect NEWS-->CHANGELOG.md rename

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,5 +4,5 @@ AUTOMAKE_OPTIONS = foreign 1.4
 
 SUBDIRS = src doc
 docdir = $(prefix)/share/doc/$(PACKAGE)
-doc_DATA = AUTHORS NEWS COPYING
+doc_DATA = AUTHORS CHANGELOG.md COPYING
 EXTRA_DIST = $(doc_DATA)


### PR DESCRIPTION
With [`d1fe67b0314759f39560031d93c337ae997e8504`](https://github.com/ncmpcpp/ncmpcpp/commit/d1fe67b0314759f39560031d93c337ae997e8504), building from master would fail: `make[2]: *** No rule to make target 'NEWS', needed by 'all-am'.  Stop.`.