### PR TITLE
Proof of concept: album artwork via Ueberzug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Darby Payne <darby.payne@gmail.com>
 David Coppa <dcoppa@gmail.com>
 Dmitriy Kusterskiy <dimykus@gmail.com>
 Eric Izoita <ericizoita@gmail.com>
+Evan Chang <evanc577@gmail.com>
 Frank Blendinger <fb@intoxicatedmind.net>
 greenbagels <greenbagels@teknik.io>
 Hamuko <hamuko@burakku.com>

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_PROG_LIBTOOL
 AC_ARG_ENABLE(outputs, AS_HELP_STRING([--enable-outputs], [Enable outputs screen @<:@default=no@:>@]), [outputs=$enableval], [outputs=no])
 AC_ARG_ENABLE(visualizer, AS_HELP_STRING([--enable-visualizer], [Enable music visualizer screen @<:@default=no@:>@]), [visualizer=$enableval], [visualizer=no])
 AC_ARG_ENABLE(clock, AS_HELP_STRING([--enable-clock], [Enable clock screen @<:@default=no@:>@]), [clock=$enableval], [clock=no])
+AC_ARG_ENABLE(artwork, AS_HELP_STRING([--enable-artwork], [Enable artwork screen @<:@default=no@:>@]), [artwork=$enableval], [artwork=no])
 
 AC_ARG_WITH(fftw, AS_HELP_STRING([--with-fftw], [Enable fftw support (required for frequency spectrum vizualization) @<:@default=auto@:>@]), [fftw=$withval], [fftw=auto])
 AC_ARG_WITH(taglib, AS_HELP_STRING([--with-taglib], [Enable tag editor @<:@default=auto@:>@]), [taglib=$withval], [taglib=auto])
@@ -25,6 +26,10 @@ fi
 
 if test "$clock" = "yes"; then
 	AC_DEFINE([ENABLE_CLOCK], [1], [enables clock screen])
+fi
+
+if test "$artwork" = "yes"; then
+	AC_DEFINE([ENABLE_ARTWORK], [1], [enables artwork screen])
 fi
 
 # -flto

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,7 @@ ncmpcpp_SOURCES = \
 	screens/tag_editor.cpp \
 	screens/tiny_tag_editor.cpp \
 	screens/visualizer.cpp \
+	screens/artwork.cpp \
 	utility/comparators.cpp \
 	utility/html.cpp \
 	utility/option_parser.cpp \

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -62,6 +62,7 @@
 #include "screens/tag_editor.h"
 #include "screens/tiny_tag_editor.h"
 #include "screens/visualizer.h"
+#include "screens/artwork.h"
 #include "title.h"
 #include "tags.h"
 
@@ -159,6 +160,10 @@ void initializeScreens()
 #	ifdef ENABLE_VISUALIZER
 	myVisualizer = new Visualizer;
 #	endif // ENABLE_VISUALIZER
+
+#	ifdef ENABLE_ARTWORK
+	myArtwork = new Artwork;
+#	endif // ENABLE_ARTWORK
 	
 #	ifdef ENABLE_OUTPUTS
 	myOutputs = new Outputs;
@@ -194,6 +199,10 @@ void setResizeFlags()
 	myVisualizer->hasToBeResized = 1;
 #	endif // ENABLE_VISUALIZER
 	
+#	ifdef ENABLE_ARTWORK
+	myArtwork->hasToBeResized = 1;
+#	endif // ENABLE_ARTWORK
+
 #	ifdef ENABLE_OUTPUTS
 	myOutputs->hasToBeResized = 1;
 #	endif // ENABLE_OUTPUTS
@@ -2746,6 +2755,15 @@ void ShowServerInfo::run()
 	myServerInfo->switchTo();
 }
 
+bool ShowArtwork::canBeRun()
+{
+	return myScreen != myArtwork;
+}
+
+void ShowArtwork::run() {
+	myArtwork->switchTo();
+}
+
 }
 
 namespace {
@@ -2884,6 +2902,7 @@ void populateActions()
 	insert_action(new Actions::ShowVisualizer());
 	insert_action(new Actions::ShowClock());
 	insert_action(new Actions::ShowServerInfo());
+	insert_action(new Actions::ShowArtwork());
 	for (size_t i = 0; i < AvailableActions.size(); ++i)
 	{
 		if (AvailableActions[i] == nullptr)

--- a/src/actions.h
+++ b/src/actions.h
@@ -164,6 +164,7 @@ enum class Type
 	ShowVisualizer,
 	ShowClock,
 	ShowServerInfo,
+	ShowArtwork,
 	_numberOfActions // needed to dynamically calculate size of action array
 };
 
@@ -1422,6 +1423,15 @@ private:
 #	ifdef HAVE_TAGLIB_H
 	virtual bool canBeRun() override;
 #	endif // HAVE_TAGLIB_H
+	virtual void run() override;
+};
+
+struct ShowArtwork: BaseAction
+{
+	ShowArtwork(): BaseAction(Type::ShowArtwork, "show_artwork") { }
+	
+private:
+	virtual bool canBeRun() override;
 	virtual void run() override;
 };
 

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -33,6 +33,7 @@
 
 #include "actions.h"
 #include "bindings.h"
+#include "screens/artwork.h"
 #include "screens/browser.h"
 #include "charset.h"
 #include "configuration.h"
@@ -47,6 +48,7 @@
 #include "screens/visualizer.h"
 #include "title.h"
 #include "utility/conversion.h"
+#include "screens/screen.h"
 
 namespace ph = std::placeholders;
 
@@ -57,7 +59,7 @@ std::streambuf *cerr_buffer;
 std::streambuf *clog_buffer;
 
 volatile bool run_resize_screen = false;
-	
+
 void sighandler(int sig)
 {
 	if (sig == SIGWINCH)
@@ -233,6 +235,11 @@ int main(int argc, char **argv)
 			catch (NC::PromptAborted &)
 			{
 				Statusbar::printf("Action aborted");
+			}
+
+			if (!isVisible(myArtwork))
+			{
+				myArtwork->removeArtwork();
 			}
 
 			if (myScreen == myPlaylist)

--- a/src/screens/artwork.cpp
+++ b/src/screens/artwork.cpp
@@ -1,0 +1,130 @@
+/***************************************************************************
+ *   Copyright (C) 2008-2021 by Andrzej Rybczak                            *
+ *   andrzej@rybczak.net                                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.              *
+ ***************************************************************************/
+
+#include "screens/artwork.h"
+
+#include <signal.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <fstream>
+
+#include "macro_utilities.h"
+#include "screens/screen_switcher.h"
+#include "statusbar.h"
+#include "title.h"
+
+using Global::MainHeight;
+using Global::MainStartY;
+
+Artwork* myArtwork;
+std::string ueberzug_fifo;
+pid_t child_pid;
+std::string current_artwork_path;
+
+extern char** environ;
+
+Artwork::Artwork()
+: Screen(NC::Window(0, MainStartY, COLS, MainHeight, "", NC::Color::Default, NC::Border()))
+{
+	pid_t parent_pid = getpid();
+	int ret;
+
+	// generate ueberzug fifo name
+	char fifo_fmt[] = "/tmp/ncmpcpp_ueberzug.%1%.fifo";
+	ueberzug_fifo = boost::str(boost::format(fifo_fmt) % parent_pid);
+	mkfifo(ueberzug_fifo.c_str(), 0666);
+	assert(ret == 0);
+
+	// start ueberzug process
+  char argv0[] = "setsid";
+	char argv1[] = "bash";
+	char argv2[] = "-c";
+	std::string cmd = boost::str(boost::format("tail --follow %1% | ueberzug layer --silent --parser simple") % ueberzug_fifo);
+	char* argv3 = strdup(cmd.c_str());
+	char* argv[] = {argv0, argv1, argv2, argv3, (char*)0};
+	posix_spawnp(&child_pid, "setsid", nullptr, nullptr, argv, environ);
+	free(argv3);
+
+	std::atexit(stopUeberzug);
+}
+
+void Artwork::stopUeberzug()
+{
+	removeArtwork();
+	std::remove(ueberzug_fifo.c_str());
+	kill(-1*child_pid, SIGTERM);
+}
+
+void Artwork::resize()
+{
+	size_t x_offset, width;
+	getWindowResizeParams(x_offset, width);
+	w.resize(width, MainHeight);
+	w.moveTo(x_offset, MainStartY);
+	updateArtwork(current_artwork_path);
+}
+
+void Artwork::switchTo() {
+	SwitchTo::execute(this);
+	drawHeader();
+}
+
+std::wstring Artwork::title() { return L"Artwork"; }
+
+void Artwork::showArtwork(std::string path, int x_offset, int y_offset, int width, int height)
+{
+	std::string dir = Config.mpd_music_dir;
+
+	std::ofstream stream;
+	stream.open(ueberzug_fifo, std::ios_base::app);
+	stream << "action\tadd\t";
+	stream << "identifier\talbumart\t";
+	stream << "synchronously_draw\tTrue\t";
+	stream << "scaler\tcontain\t";
+	stream << "scaling_position_x\t0.5\t";
+	stream << "scaling_position_y\t0.5\t";
+	stream << "path\t" << path << "\t";
+	stream << "x\t" << x_offset << "\t";
+	stream << "y\t" << y_offset << "\t";
+	stream << "width\t" << width << "\t";
+	stream << "height\t" << height << "\n";
+}
+
+void Artwork::removeArtwork()
+{
+	std::ofstream stream;
+	stream.open(ueberzug_fifo, std::ios_base::app);
+	stream << "action\tremove\t"
+		"identifier\talbumart\n";
+}
+
+void Artwork::updateArtwork(std::string path) {
+	if (isVisible(myArtwork))
+	{
+		size_t x_offset, width;
+		myArtwork->getWindowResizeParams(x_offset, width);
+		std::string fullpath = Config.mpd_music_dir + path + "/cover.jpg";
+		showArtwork(fullpath, x_offset, MainStartY, width, MainHeight);
+		current_artwork_path = path;
+	}
+}

--- a/src/screens/artwork.h
+++ b/src/screens/artwork.h
@@ -18,52 +18,45 @@
  *   51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.              *
  ***************************************************************************/
 
-#ifndef NCMPCPP_SCREEN_TYPE_H
-#define NCMPCPP_SCREEN_TYPE_H
+#ifndef NCMPCPP_ARTWORK_H
+#define NCMPCPP_ARTWORK_H
 
-#include <string>
 #include "config.h"
 
-// forward declaration
-struct BaseScreen;
+#ifdef ENABLE_ARTWORK
 
-enum class ScreenType {
-	Browser,
-#	ifdef ENABLE_CLOCK
-	Clock,
-#	endif // ENABLE_CLOCK
-	Help,
-	Lastfm,
-	Lyrics,
-	MediaLibrary,
-#	ifdef ENABLE_OUTPUTS
-	Outputs,
-#	endif // ENABLE_OUTPUTS
-	Playlist,
-	PlaylistEditor,
-	SearchEngine,
-	SelectedItemsAdder,
-	ServerInfo,
-	SongInfo,
-	SortPlaylistDialog,
-#	ifdef HAVE_TAGLIB_H
-	TagEditor,
-	TinyTagEditor,
-#	endif // HAVE_TAGLIB_H
-	Unknown,
-#	ifdef ENABLE_VISUALIZER
-	Visualizer,
-#	endif // ENABLE_VISUALIZER
-#	ifdef ENABLE_ARTWORK
-	Artwork,
-#	endif // ENABLE_ARTWORK
+#include "curses/window.h"
+#include "interfaces.h"
+#include "screens/screen.h"
+
+struct Artwork: Screen<NC::Window>, Tabbable
+{
+	Artwork();
+	
+	virtual void resize() override;
+	virtual void switchTo() override;
+	
+	virtual std::wstring title() override;
+	virtual ScreenType type() override { return ScreenType::Artwork; }
+	
+	virtual void update() override { }
+	virtual void scroll(NC::Scroll) override { }
+	
+	virtual void mouseButtonPressed(MEVENT) override { }
+	
+	virtual bool isLockable() override { return true; }
+	virtual bool isMergable() override { return true; }
+
+	static void removeArtwork();
+	static void showArtwork(std::string path, int x_offset, int y_offset, int width, int height);
+	static void updateArtwork(std::string path);
+
+private:
+	static void stopUeberzug();
 };
 
-std::string screenTypeToString(ScreenType st);
+extern Artwork *myArtwork;
 
-ScreenType stringtoStartupScreenType(const std::string &s);
-ScreenType stringToScreenType(const std::string &s);
+#endif // ENABLE_ARTWORK
 
-BaseScreen *toScreen(ScreenType st);
-
-#endif // NCMPCPP_SCREEN_TYPE_H
+#endif // NCMPCPP_ARTWORK_H

--- a/src/screens/screen_type.cpp
+++ b/src/screens/screen_type.cpp
@@ -38,6 +38,7 @@
 #include "screens/tag_editor.h"
 #include "screens/tiny_tag_editor.h"
 #include "screens/visualizer.h"
+#include "screens/artwork.h"
 
 std::string screenTypeToString(ScreenType st)
 {
@@ -87,6 +88,10 @@ std::string screenTypeToString(ScreenType st)
 	case ScreenType::Visualizer:
 		return "visualizer";
 #endif // ENABLE_VISUALIZER
+#ifdef ENABLE_ARTWORK
+	case ScreenType::Artwork:
+		return "artwork";
+#endif // ENABLE_ARTWORK
 	}
 	// silence gcc warning
 	throw std::runtime_error("unreachable");
@@ -123,6 +128,10 @@ ScreenType stringtoStartupScreenType(const std::string &s)
 	else if (s == "visualizer")
 		result = ScreenType::Visualizer;
 #	endif // ENABLE_VISUALIZER
+#	ifdef ENABLE_ARTWORK
+	else if (s == "artwork")
+		result = ScreenType::Artwork;
+#	endif // ENABLE_ARTWORK
 	else if (s == "lyrics")
 		result = ScreenType::Lyrics;
 	else if (s == "last_fm")
@@ -201,6 +210,10 @@ BaseScreen *toScreen(ScreenType st)
 		case ScreenType::Visualizer:
 			return myVisualizer;
 #		endif // ENABLE_VISUALIZER
+#		ifdef ENABLE_ARTWORK
+		case ScreenType::Artwork:
+			return myArtwork;
+#		endif // ENABLE_ARTWORK
 		default:
 			return nullptr;
 	}

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -23,6 +23,7 @@
 #include <netinet/in.h>
 
 #include "curses/menu_impl.h"
+#include "screens/artwork.h"
 #include "screens/browser.h"
 #include "charset.h"
 #include "format_impl.h"
@@ -584,6 +585,10 @@ void Status::Changes::songID(int song_id)
 			    && isVisible(myLyrics)
 			    && myLyrics->previousScreen() == myPlaylist)
 				myLyrics->fetch(s);
+
+#	ifdef ENABLE_ARTWORK
+			myArtwork->updateArtwork(s.getDirectory());
+#	endif // ENABLE_ARTWORK
 		}
 	}
 	elapsedTime(false);


### PR DESCRIPTION
Quick proof of concept for displaying album art with [Ueberzug](https://github.com/seebye/ueberzug). 

Added a new "artwork" screen that can be resized and positioned using existing ncmpcpp functions. It looks for a file called `cover.jpg` in the currently playing song's directory relative to the `mpd_music_dir` config value. The artwork is updated and drawn on if the artwork screen is visible and the song changes, or if the screen is resized.

Some current limitations:

* No support for embedded artwork.
* Doesn't use mpd's native `albumart`, libmpdclient has not implemented this functionality yet anyways.
* Only searches for "cover.jpg" in directory.
* Artwork is aligned at the top-left of screen. Centering it probably requires parsing the image with imagemagick. As far as I can tell, Ueberzug doesn't make this possible by itself.
* If using split screens and a popup appears (such as when adding a song to a playlist), the artwork disappears and need to switch/reload screens to make it appear again.
* Configure script doesn't check whether Ueberzug is installed or not.

Dirty hacks that probably need to go away:

* Uses `posix_spawn()` to start ueberzug, kills it on exit with `std::atexit()` and `kill()`. If ncmpcpp crashes and terminates abnormally, the spawned process will not be terminated.
* Ueberzug is hardcoded, should refactor so other viable backends can be easily added.

Use `./configure --enable-artwork` flag to compile artwork support.

# Screenshots

```
mpd_music_dir = "/path/to/mpd/library"
startup_screen = artwork
startup_slave_screen = playlist
startup_slave_screen_focus = yes
locked_screen_width_part = 25
```

![Screenshot_20210103_154138](https://user-images.githubusercontent.com/14303970/103489122-25601900-4de0-11eb-8b07-1846c66e8c9a.png)

![Screenshot_20210103_154214](https://user-images.githubusercontent.com/14303970/103489126-28f3a000-4de0-11eb-950d-74424281719b.png)

![Screenshot_20210103_154719](https://user-images.githubusercontent.com/14303970/103489128-2b55fa00-4de0-11eb-94d1-53003b3312d5.png)
