### PR TITLE
Prevent duplicates when adding selected items to playlist

### DIFF
--- a/src/screens/sel_items_adder.cpp
+++ b/src/screens/sel_items_adder.cpp
@@ -284,7 +284,7 @@ void SelectedItemsAdder::addToExistingPlaylist(const std::string &playlist) cons
 {
 	for (auto s = m_selected_items.begin(); s != m_selected_items.end(); ++s){
 		for (MPD::SongIterator s2 = Mpd.GetPlaylistContent(playlist), end; s2 != end; ++s2)
-			if(s2->getID() == s->getID()){
+			if(s2->getURI() == s->getURI()){
 				goto next_song;
 			}
 		Mpd.StartCommandsList();

--- a/src/screens/sel_items_adder.cpp
+++ b/src/screens/sel_items_adder.cpp
@@ -282,10 +282,17 @@ void SelectedItemsAdder::addToNewPlaylist() const
 
 void SelectedItemsAdder::addToExistingPlaylist(const std::string &playlist) const
 {
-	Mpd.StartCommandsList();
-	for (auto s = m_selected_items.begin(); s != m_selected_items.end(); ++s)
+	for (auto s = m_selected_items.begin(); s != m_selected_items.end(); ++s){
+		for (MPD::SongIterator s2 = Mpd.GetPlaylistContent(playlist), end; s2 != end; ++s2)
+			if(s2->getID() == s->getID()){
+				goto next_song;
+			}
+		Mpd.StartCommandsList();
 		Mpd.AddToPlaylist(playlist, *s);
-	Mpd.CommitCommandsList();
+		Mpd.CommitCommandsList();
+		next_song:;
+	}
+
 	Statusbar::printf("Selected item(s) added to playlist \"%1%\"", playlist);
 	switchToPreviousScreen();
 }


### PR DESCRIPTION
~~It seems like the song ID changes from one playlist to another, is that why this doesn't work?~~

The song ID doesn't change, it's just [undefined for songs not obtained from the queue](https://www.musicpd.org/doc/libmpdclient/song_8h.html#a9d1d9a2eac8e567de3604a6ed4cc3694).

