### PR TITLE
Allow moving the SelectedItemsAdder popup by a given offset

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,3 +47,4 @@ Wieland Hoffmann <themineo@gmail.com>
 Wojciech Siewierski <wojciech.siewierski@onet.pl>
 Yannick LM <yannicklm1337@gmail.com>
 V <v@anomalous.eu>
+Jojii <jojii@gmx.net>

--- a/src/screens/sel_items_adder.cpp
+++ b/src/screens/sel_items_adder.cpp
@@ -57,9 +57,11 @@ SelectedItemsAdder::SelectedItemsAdder()
 	using Global::MainHeight;
 	using Global::MainStartY;
 	setDimensions();
-	
+
+	size_t x_col_offset = std::floor((Config.selected_item_x_offset/100.0f)*(COLS-m_playlist_selector_width));
+
 	m_playlist_selector = Component(
-		(COLS-m_playlist_selector_width)/2,
+		((COLS-m_playlist_selector_width)+x_col_offset)/2,
 		MainStartY+(MainHeight-m_playlist_selector_height)/2,
 		m_playlist_selector_width,
 		m_playlist_selector_height,
@@ -73,7 +75,7 @@ SelectedItemsAdder::SelectedItemsAdder()
 	m_playlist_selector.setItemDisplayer(DisplayComponent);
 	
 	m_position_selector = Component(
-		(COLS-m_position_selector_width)/2,
+		((COLS-m_playlist_selector_width)+x_col_offset)/2,
 		MainStartY+(MainHeight-m_position_selector_height)/2,
 		m_position_selector_width,
 		m_position_selector_height,
@@ -135,14 +137,17 @@ void SelectedItemsAdder::resize()
 	using Global::MainHeight;
 	using Global::MainStartY;
 	setDimensions();
+
+	size_t x_col_offset = std::floor((Config.selected_item_x_offset/100.0f)*(COLS-m_playlist_selector_width));
+
 	m_playlist_selector.resize(m_playlist_selector_width, m_playlist_selector_height);
 	m_playlist_selector.moveTo(
-		(COLS-m_playlist_selector_width)/2,
+		((COLS-m_playlist_selector_width)+x_col_offset)/2,
 		MainStartY+(MainHeight-m_playlist_selector_height)/2
 	);
 	m_position_selector.resize(m_position_selector_width, m_position_selector_height);
 	m_position_selector.moveTo(
-		(COLS-m_position_selector_width)/2,
+		((COLS-m_playlist_selector_width)+x_col_offset)/2,
 		MainStartY+(MainHeight-m_position_selector_height)/2
 	);
 	if (previousScreen() && previousScreen()->hasToBeResized) // resize background window
@@ -353,7 +358,7 @@ void SelectedItemsAdder::setDimensions()
 	
 	m_playlist_selector_width = COLS*0.6;
 	m_playlist_selector_height = std::min(MainHeight, size_t(LINES*0.66));
-	
+
 	m_position_selector_width = std::min(size_t(35), size_t(COLS));
 	m_position_selector_height = std::min(size_t(11), MainHeight);
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -386,6 +386,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	                nullptr,
 	                std::ref(selected_item_suffix_length),
 	                ph::_1));
+  	p.add("selected_item_x_offset", &selected_item_x_offset, "1");
 	p.add("modified_item_prefix", &modified_item_prefix, "$3>$9 ", buffer);
 	p.add("song_window_title_format", &song_window_title_format,
 	      "{%a - }{%t}|{%f}", [](std::string v) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -203,6 +203,7 @@ struct Configuration
 
 	size_t selected_item_prefix_length;
 	size_t selected_item_suffix_length;
+	size_t selected_item_x_offset;
 	size_t now_playing_prefix_length;
 	size_t now_playing_suffix_length;
 	size_t current_item_prefix_length;


### PR DESCRIPTION
Move the 'add selected to playlist' popup by a given value in percent on the X axis. Resolves potentially overlapping album art images (#437) in some configurations.

config entry:
`selected_item_x_offset = <-100 to 100>`<br>

## Before
![before](https://user-images.githubusercontent.com/15957865/110217546-d81e2780-7eb4-11eb-9705-dd3504703649.png)

## After
![after](https://user-images.githubusercontent.com/15957865/110217513-a86f1f80-7eb4-11eb-9d08-257797daf388.png)
