### PR TITLE
Fix vorbis comment and add support for Opus

### DIFF
--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -174,7 +174,7 @@ void writeXiphComments(const MPD::MutableSong &s, TagLib::Ogg::XiphComment *tag)
 {
 	auto writeXiph = [&](const TagLib::String &type, const TagLib::StringList &list) {
 		for (auto it = list.begin(); it != list.end(); ++it)
-			tag->addField(type, *it);
+			tag->addField(type, *it, it == list.begin());
 	};
 	// remove field previously used as album artist
 	tag->removeFields("ALBUM ARTIST");

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -29,6 +29,7 @@
 #include <flacfile.h>
 #include <mpegfile.h>
 #include <vorbisfile.h>
+#include <opusfile.h>
 #include <tag.h>
 #include <textidentificationframe.h>
 #include <commentsframe.h>
@@ -229,15 +230,21 @@ bool extendedSetSupported(const TagLib::File *f)
 {
 	return dynamic_cast<const TagLib::MPEG::File *>(f)
 	||     dynamic_cast<const TagLib::Ogg::Vorbis::File *>(f)
+	||     dynamic_cast<const TagLib::Ogg::Opus::File *>(f)
 	||     dynamic_cast<const TagLib::FLAC::File *>(f);
 }
 
 ReplayGainInfo readReplayGain(TagLib::File *f)
 {
 	ReplayGainInfo result;
-	if (auto ogg_file = dynamic_cast<TagLib::Ogg::Vorbis::File *>(f))
+	if (auto vorbis_file = dynamic_cast<TagLib::Ogg::Vorbis::File *>(f))
 	{
-		if (auto xiph = ogg_file->tag())
+		if (auto xiph = vorbis_file->tag())
+			result = getReplayGain(xiph);
+	}
+	else if (auto opus_file = dynamic_cast<TagLib::Ogg::Opus::File *>(f))
+	{
+		if (auto xiph = opus_file->tag())
 			result = getReplayGain(xiph);
 	}
 	else if (auto flac_file = dynamic_cast<TagLib::FLAC::File *>(f))
@@ -264,9 +271,14 @@ void read(mpd_song *s)
 		else if (auto id3v1 = mpeg_file->ID3v1Tag())
 			readID3v1Tags(s, id3v1);
 	}
-	else if (auto ogg_file = dynamic_cast<TagLib::Ogg::Vorbis::File *>(f.file()))
+	else if (auto vorbis_file = dynamic_cast<TagLib::Ogg::Vorbis::File *>(f.file()))
 	{
-		if (auto xiph = ogg_file->tag())
+		if (auto xiph = vorbis_file->tag())
+			readXiphComments(s, xiph);
+	}
+	else if (auto opus_file = dynamic_cast<TagLib::Ogg::Opus::File *>(f.file()))
+	{
+		if (auto xiph = opus_file->tag())
 			readXiphComments(s, xiph);
 	}
 	else if (auto flac_file = dynamic_cast<TagLib::FLAC::File *>(f.file()))
@@ -299,9 +311,13 @@ bool write(MPD::MutableSong &s)
 		// do not call generic save() as it will duplicate tags
 		saved = true;
 	}
-	else if (auto ogg_file = dynamic_cast<TagLib::Ogg::Vorbis::File *>(f.file()))
+	else if (auto vorbis_file = dynamic_cast<TagLib::Ogg::Vorbis::File *>(f.file()))
 	{
-		writeXiphComments(s, ogg_file->tag());
+		writeXiphComments(s, vorbis_file->tag());
+	}
+	else if (auto opus_file = dynamic_cast<TagLib::Ogg::Opus::File *>(f.file()))
+	{
+		writeXiphComments(s, opus_file->tag());
 	}
 	else if (auto flac_file = dynamic_cast<TagLib::FLAC::File *>(f.file()))
 	{


### PR DESCRIPTION
- fixes a bug where editing Vorbis comment doesn't support multiple values.
To reproduce: open tag editor, change some field of a FLAC or Ogg Vorbis file to contain multiple values, save. Now only the last value is saved.

- adds Vorbis comment support for Opus.