### PR TITLE
Tweaks to frequency spectrum and sound ellipse in visualizer

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -49,10 +49,10 @@
 ## the relevant section for mpd.conf:
 ##
 ## audio_output {
-##        type            "fifo"
-##        name            "Visualizer feed"
-##        path            "/tmp/mpd.fifo"
-##        format          "44100:16:2"
+##		type			"fifo"
+##		name			"Visualizer feed"
+##		path			"/tmp/mpd.fifo"
+##		format		  "44100:16:2"
 ## }
 ##
 ## If the visualization on occasion diverges from the audio output, please set
@@ -64,8 +64,8 @@
 ##
 ## [audio]
 ## output = tee name=t ! queue ! autoaudiosink t.
-##        ! queue ! audio/x-raw,rate=44100,channels=2,format=S16LE
-##        ! udpsink host=localhost port=5555
+##		! queue ! audio/x-raw,rate=44100,channels=2,format=S16LE
+##		! udpsink host=localhost port=5555
 ##
 ## will make localhost:5555 available as a source of data for the stereo
 ## visualizer.
@@ -143,8 +143,8 @@
 #
 ## Use log scaling for the frequency spectrum axes
 #
-#visualizer_spectrum_log_scale_x = no
-#visualizer_spectrum_log_scale_y = no
+#visualizer_spectrum_log_scale_x = yes
+#visualizer_spectrum_log_scale_y = yes
 #
 ##### system encoding #####
 ##
@@ -540,11 +540,11 @@
 ## - 1 - use mpd built-in searching (no regexes, pattern matching)
 ##
 ## - 2 - use ncmpcpp searching (pattern matching with support for regexes, but
-##       if your mpd is on a remote machine, downloading big database to process
-##       it can take a while
+##	   if your mpd is on a remote machine, downloading big database to process
+##	   it can take a while
 ##
 ## - 3 - match only exact values (this mode uses mpd function for searching in
-##       database and local one for searching in current playlist)
+##	   database and local one for searching in current playlist)
 ##
 #
 #search_engine_default_search_mode = 1

--- a/doc/config
+++ b/doc/config
@@ -49,10 +49,10 @@
 ## the relevant section for mpd.conf:
 ##
 ## audio_output {
-##		type			"fifo"
-##		name			"Visualizer feed"
-##		path			"/tmp/mpd.fifo"
-##		format		  "44100:16:2"
+##        type            "fifo"
+##        name            "Visualizer feed"
+##        path            "/tmp/mpd.fifo"
+##        format          "44100:16:2"
 ## }
 ##
 ## If the visualization on occasion diverges from the audio output, please set
@@ -64,8 +64,8 @@
 ##
 ## [audio]
 ## output = tee name=t ! queue ! autoaudiosink t.
-##		! queue ! audio/x-raw,rate=44100,channels=2,format=S16LE
-##		! udpsink host=localhost port=5555
+##        ! queue ! audio/x-raw,rate=44100,channels=2,format=S16LE
+##        ! udpsink host=localhost port=5555
 ##
 ## will make localhost:5555 available as a source of data for the stereo
 ## visualizer.
@@ -540,11 +540,11 @@
 ## - 1 - use mpd built-in searching (no regexes, pattern matching)
 ##
 ## - 2 - use ncmpcpp searching (pattern matching with support for regexes, but
-##	   if your mpd is on a remote machine, downloading big database to process
-##	   it can take a while
+##       if your mpd is on a remote machine, downloading big database to process
+##       it can take a while
 ##
 ## - 3 - match only exact values (this mode uses mpd function for searching in
-##	   database and local one for searching in current playlist)
+##       database and local one for searching in current playlist)
 ##
 #
 #search_engine_default_search_mode = 1

--- a/doc/config
+++ b/doc/config
@@ -141,6 +141,11 @@
 #
 #visualizer_spectrum_hz_max = 20000
 #
+## Use log scaling for the frequency spectrum axes
+#
+#visualizer_spectrum_log_scale_x = no
+#visualizer_spectrum_log_scale_y = no
+#
 ##### system encoding #####
 ##
 ## ncmpcpp should detect your charset encoding but if it failed to do so, you

--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -83,9 +83,7 @@ Visualizer::Visualizer()
   HZ_MIN(Config.visualizer_spectrum_hz_min),
   HZ_MAX(Config.visualizer_spectrum_hz_max),
   GAIN(Config.visualizer_spectrum_gain),
-  SMOOTH_CHARS(ToWString("▁▂▃▄▅▆▇█")),
-  LOG_SCALE_X(Config.visualizer_spectrum_log_scale_x),
-  LOG_SCALE_Y(Config.visualizer_spectrum_log_scale_y)
+  SMOOTH_CHARS(ToWString("▁▂▃▄▅▆▇█"))
 #endif
 {
 	InitDataSource();
@@ -97,7 +95,7 @@ Visualizer::Visualizer()
 	memset(m_fftw_input, 0, sizeof(double)*DFT_TOTAL_SIZE);
 	m_fftw_output = static_cast<fftw_complex *>(fftw_malloc(sizeof(fftw_complex)*m_fftw_results));
 	m_fftw_plan = fftw_plan_dft_r2c_1d(DFT_TOTAL_SIZE, m_fftw_input, m_fftw_output, FFTW_ESTIMATE);
-    m_dft_freqspace.reserve(500);
+	m_dft_freqspace.reserve(500);
 	m_bar_heights.reserve(100);
 #	endif // HAVE_FFTW3_H
 }
@@ -109,7 +107,7 @@ void Visualizer::switchTo()
 	m_reset_output = true;
 	drawHeader();
 #	ifdef HAVE_FFTW3_H
-    GenFreqSpace();
+	GenFreqSpace();
 	m_bar_heights.reserve(w.getWidth());
 #	endif // HAVE_FFTW3_H
 }
@@ -123,7 +121,7 @@ void Visualizer::resize()
 	hasToBeResized = 0;
 	InitVisualization();
 #	ifdef HAVE_FFTW3_H
-    GenFreqSpace();
+	GenFreqSpace();
 	m_bar_heights.reserve(w.getWidth());
 #	endif // HAVE_FFTW3_H
 }
@@ -151,7 +149,7 @@ void Visualizer::update()
 	// PCM in format 44100:16:1 (for mono visualization) and
 	// 44100:16:2 (for stereo visualization) is supported.
 	ssize_t bytes_read = read(m_source_fd, m_incoming_samples.data(),
-	                          sizeof(int16_t) * m_incoming_samples.size());
+							  sizeof(int16_t) * m_incoming_samples.size());
 	if (bytes_read > 0)
 	{
 		const auto begin = m_incoming_samples.begin();
@@ -190,7 +188,7 @@ void Visualizer::update()
 		requested_samples *= 2;
 
 	//Statusbar::printf("Samples: %1%, %2%, %3%", m_buffered_samples.size(),
-	//                  requested_samples, m_sample_consumption_rate);
+	//				  requested_samples, m_sample_consumption_rate);
 
 	size_t new_samples = m_buffered_samples.get(requested_samples, m_rendered_samples);
 	if (new_samples == 0)
@@ -477,19 +475,19 @@ void Visualizer::DrawFrequencySpectrum(const int16_t *buf, ssize_t samples, size
 		// average bins
 		bar_height /= count;
 
-        // apply scaling to bar heights
-        if (LOG_SCALE_Y) {
-            bar_height = (20 * log10(bar_height) + DYNAMIC_RANGE + GAIN) / DYNAMIC_RANGE;
-        } else {
-            // apply gain
-            bar_height *= pow(10, 1.8 + GAIN / 20);
-            // buff higher frequencies
-            bar_height *= log2(2 + x) * 80.0/win_width;
-            // moderately normalize the heights
-            bar_height = pow(bar_height, 0.65);
+		// apply scaling to bar heights
+		if (Config.visualizer_spectrum_log_scale_y) {
+			bar_height = (20 * log10(bar_height) + DYNAMIC_RANGE + GAIN) / DYNAMIC_RANGE;
+		} else {
+			// apply gain
+			bar_height *= pow(10, 1.8 + GAIN / 20);
+			// buff higher frequencies
+			bar_height *= log2(2 + x) * 80.0/win_width;
+			// moderately normalize the heights
+			bar_height = pow(bar_height, 0.65);
 
-            //bar_height = pow(10, 1 + GAIN / 20) * bar_height;
-        }
+			//bar_height = pow(10, 1 + GAIN / 20) * bar_height;
+		}
 		// Scale bar height between 0 and height
 		bar_height = bar_height > 0 ? bar_height * height : 0;
 		bar_height = bar_height > height ? height : bar_height;
@@ -511,11 +509,11 @@ void Visualizer::DrawFrequencySpectrum(const int16_t *buf, ssize_t samples, size
 				++h_idx;
 		} else {
 			// data point does not exist, need to interpolate
-            if (LOG_SCALE_X) {
-                h = Interpolate(x, h_idx);
-            } else {
-                h = 0;
-            }
+			if (Config.visualizer_spectrum_log_scale_x) {
+				h = Interpolate(x, h_idx);
+			} else {
+				h = 0;
+			}
 		}
 
 		for (size_t j = 0; j < h; ++j)
@@ -644,26 +642,27 @@ void Visualizer::GenLogspace()
 // Generate vector of linearly-spaced frequencies from HZ_MIN to HZ_MAX
 void Visualizer::GenLinspace()
 {
-    // Calculate number of extra bins needed between 0 HZ and HZ_MIN
-    const size_t win_width = w.getWidth();
-    const size_t left_bins = (HZ_MIN - win_width * HZ_MIN) / (HZ_MIN - HZ_MAX);
-    // Generate linspaced frequencies
-    m_dft_freqspace.resize(win_width);
-    const double lin_scale = HZ_MAX / (left_bins + m_dft_freqspace.size() - 1);
-    for (size_t i = left_bins; i < m_dft_freqspace.size() + left_bins; ++i) {
-        m_dft_freqspace[i - left_bins] = i * lin_scale;
-    }
+	// Calculate number of extra bins needed between 0 HZ and HZ_MIN
+	const size_t win_width = w.getWidth();
+	const size_t left_bins = (HZ_MIN - win_width * HZ_MIN) / (HZ_MIN - HZ_MAX);
+	// Generate linspaced frequencies
+	m_dft_freqspace.resize(win_width);
+	const double lin_scale = HZ_MAX / (left_bins + m_dft_freqspace.size() - 1);
+	for (size_t i = left_bins; i < m_dft_freqspace.size() + left_bins; ++i) {
+		m_dft_freqspace[i - left_bins] = i * lin_scale;
+	}
 }
 
 // Generate vector of spectrum frequencies from HZ_MIN to HZ_MAX
-// Frequencies are (not) log-scaled depending on LOG_SCALE_X
+// Frequencies are (not) log-scaled depending on
+// Config.visualizer_spectrum_log_scale_x
 void Visualizer::GenFreqSpace()
 {
-    if (LOG_SCALE_X) {
-        GenLogspace();
-    } else {
-        GenLinspace();
-    }
+	if (Config.visualizer_spectrum_log_scale_x) {
+		GenLogspace();
+	} else {
+		GenLinspace();
+	}
 }
 #endif // HAVE_FFTW3_H
 
@@ -748,7 +747,7 @@ void Visualizer::Clear()
 		ssize_t bytes_read;
 		do
 			bytes_read = read(m_source_fd, m_incoming_samples.data(),
-			                  sizeof(int16_t) * m_incoming_samples.size());
+							  sizeof(int16_t) * m_incoming_samples.size());
 		while (bytes_read > 0);
 	}
 
@@ -795,11 +794,11 @@ void Visualizer::OpenDataSource()
 		hints.ai_protocol = IPPROTO_UDP;
 
 		int errcode = getaddrinfo(m_source_location.c_str(), m_source_port.c_str(),
-		                          &hints, &res);
+								  &hints, &res);
 		if (errcode != 0)
 		{
 			Statusbar::printf("Couldn't resolve \"%1%:%2%\": %3%",
-			                  m_source_location, m_source_port, gai_strerror(errcode));
+							  m_source_location, m_source_port, gai_strerror(errcode));
 			return;
 		}
 
@@ -832,7 +831,7 @@ void Visualizer::OpenDataSource()
 		m_source_fd = open(m_source_location.c_str(), O_RDONLY | O_NONBLOCK);
 		if (m_source_fd < 0)
 			Statusbar::printf("Couldn't open \"%1%\" for reading PCM data: %2%",
-			                  m_source_location, strerror(errno));
+							  m_source_location, strerror(errno));
 	}
 }
 

--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -511,7 +511,7 @@ void Visualizer::DrawFrequencySpectrum(const int16_t *buf, ssize_t samples, size
 				++h_idx;
 		} else {
 			// data point does not exist, need to interpolate
-            if (LOG_SCALE_Y) {
+            if (LOG_SCALE_X) {
                 h = Interpolate(x, h_idx);
             } else {
                 h = 0;

--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -422,7 +422,7 @@ void Visualizer::DrawSoundEllipseStereo(const int16_t *buf_left, const int16_t *
 		auto c = toColor(sqrt(x*x + 4*y*y), radius, true);
 		w << NC::XY(left_half_width + x, top_half_height + y)
 		  << c
-		  << Config.visualizer_chars[1]
+		  << Config.visualizer_chars[0]
 		  << NC::FormattedColor::End<>(c);
 	}
 }

--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -149,7 +149,7 @@ void Visualizer::update()
 	// PCM in format 44100:16:1 (for mono visualization) and
 	// 44100:16:2 (for stereo visualization) is supported.
 	ssize_t bytes_read = read(m_source_fd, m_incoming_samples.data(),
-							  sizeof(int16_t) * m_incoming_samples.size());
+	                          sizeof(int16_t) * m_incoming_samples.size());
 	if (bytes_read > 0)
 	{
 		const auto begin = m_incoming_samples.begin();
@@ -188,7 +188,7 @@ void Visualizer::update()
 		requested_samples *= 2;
 
 	//Statusbar::printf("Samples: %1%, %2%, %3%", m_buffered_samples.size(),
-	//				  requested_samples, m_sample_consumption_rate);
+	//                  requested_samples, m_sample_consumption_rate);
 
 	size_t new_samples = m_buffered_samples.get(requested_samples, m_rendered_samples);
 	if (new_samples == 0)
@@ -775,7 +775,7 @@ void Visualizer::Clear()
 		ssize_t bytes_read;
 		do
 			bytes_read = read(m_source_fd, m_incoming_samples.data(),
-							  sizeof(int16_t) * m_incoming_samples.size());
+			                  sizeof(int16_t) * m_incoming_samples.size());
 		while (bytes_read > 0);
 	}
 
@@ -822,11 +822,11 @@ void Visualizer::OpenDataSource()
 		hints.ai_protocol = IPPROTO_UDP;
 
 		int errcode = getaddrinfo(m_source_location.c_str(), m_source_port.c_str(),
-								  &hints, &res);
+		                          &hints, &res);
 		if (errcode != 0)
 		{
 			Statusbar::printf("Couldn't resolve \"%1%:%2%\": %3%",
-							  m_source_location, m_source_port, gai_strerror(errcode));
+			                  m_source_location, m_source_port, gai_strerror(errcode));
 			return;
 		}
 
@@ -859,7 +859,7 @@ void Visualizer::OpenDataSource()
 		m_source_fd = open(m_source_location.c_str(), O_RDONLY | O_NONBLOCK);
 		if (m_source_fd < 0)
 			Statusbar::printf("Couldn't open \"%1%\" for reading PCM data: %2%",
-							  m_source_location, strerror(errno));
+			                  m_source_location, strerror(errno));
 	}
 }
 

--- a/src/screens/visualizer.h
+++ b/src/screens/visualizer.h
@@ -113,8 +113,6 @@ private:
 	const double DYNAMIC_RANGE;
 	const double HZ_MIN;
 	const double HZ_MAX;
-	const bool LOG_SCALE_X;
-	const bool LOG_SCALE_Y;
 	const double GAIN;
 	const std::wstring SMOOTH_CHARS;
 	std::vector<double> m_dft_freqspace;

--- a/src/screens/visualizer.h
+++ b/src/screens/visualizer.h
@@ -79,7 +79,8 @@ private:
 	void GenLinspace();
 	void GenFreqSpace();
 	double Bin2Hz(size_t);
-	double Interpolate(size_t, size_t);
+	double InterpolateCubic(size_t, size_t);
+	double InterpolateLinear(size_t, size_t);
 #	endif // HAVE_FFTW3_H
 
 	void InitDataSource();

--- a/src/screens/visualizer.h
+++ b/src/screens/visualizer.h
@@ -76,6 +76,8 @@ private:
 	void DrawFrequencySpectrumStereo(const int16_t *, const int16_t *, ssize_t, size_t);
 	void ApplyWindow(double *, const int16_t *, ssize_t);
 	void GenLogspace();
+	void GenLinspace();
+	void GenFreqSpace();
 	double Bin2Hz(size_t);
 	double Interpolate(size_t, size_t);
 #	endif // HAVE_FFTW3_H
@@ -111,9 +113,11 @@ private:
 	const double DYNAMIC_RANGE;
 	const double HZ_MIN;
 	const double HZ_MAX;
+	const bool LOG_SCALE_X;
+	const bool LOG_SCALE_Y;
 	const double GAIN;
 	const std::wstring SMOOTH_CHARS;
-	std::vector<double> m_dft_logspace;
+	std::vector<double> m_dft_freqspace;
 	std::vector<std::pair<size_t, double>> m_bar_heights;
 
 	std::vector<double> m_freq_magnitudes;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -277,6 +277,8 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			lowerBoundCheck<double>(result, Config.visualizer_spectrum_hz_min+1);
 			return result;
 			});
+    p.add("visualizer_spectrum_log_scale_x", &visualizer_spectrum_log_scale_x, "no", yes_no);
+    p.add("visualizer_spectrum_log_scale_y", &visualizer_spectrum_log_scale_y, "no", yes_no);
 	p.add("visualizer_color", &visualizer_colors,
 	      "blue, cyan, green, yellow, magenta, red", list_of<NC::FormattedColor>);
 	p.add("system_encoding", &system_encoding, "", [](std::string encoding) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -180,8 +180,8 @@ NC::Buffer buffer(const std::string &v)
 }
 
 NC::Buffer buffer_wlength(const NC::Buffer *target,
-                          size_t &wlength,
-                          const std::string &v)
+						  size_t &wlength,
+						  const std::string &v)
 {
 	// Compatibility layer between highlight color and new highlight prefix and
 	// suffix. Basically, for older configurations if highlight color is provided,
@@ -197,11 +197,11 @@ NC::Buffer buffer_wlength(const NC::Buffer *target,
 }
 
 void deprecated(const char *option, const char *version_removal,
-                const std::string &advice)
+				const std::string &advice)
 {
 	std::cerr << "WARNING: Variable '" << option
-	          << "' is deprecated and will be removed in "
-	          << version_removal;
+			  << "' is deprecated and will be removed in "
+			  << version_removal;
 	if (!advice.empty())
 		std::cerr << " (" << advice << ")";
 	std::cerr << ".\n";
@@ -235,9 +235,9 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("visualizer_in_stereo", &visualizer_in_stereo, "yes", yes_no);
 	p.add("visualizer_type", &visualizer_type,
 #ifdef HAVE_FFTW3_H
-	      "spectrum"
+		  "spectrum"
 #else
-	      "ellipse"
+		  "ellipse"
 #endif
 		);
 	p.add("visualizer_look", &visualizer_chars, "●▮", [](std::string s) {
@@ -277,10 +277,10 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			lowerBoundCheck<double>(result, Config.visualizer_spectrum_hz_min+1);
 			return result;
 			});
-    p.add("visualizer_spectrum_log_scale_x", &visualizer_spectrum_log_scale_x, "no", yes_no);
-    p.add("visualizer_spectrum_log_scale_y", &visualizer_spectrum_log_scale_y, "no", yes_no);
+	p.add("visualizer_spectrum_log_scale_x", &visualizer_spectrum_log_scale_x, "yes", yes_no);
+	p.add("visualizer_spectrum_log_scale_y", &visualizer_spectrum_log_scale_y, "yes", yes_no);
 	p.add("visualizer_color", &visualizer_colors,
-	      "blue, cyan, green, yellow, magenta, red", list_of<NC::FormattedColor>);
+		  "blue, cyan, green, yellow, magenta, red", list_of<NC::FormattedColor>);
 	p.add("system_encoding", &system_encoding, "", [](std::string encoding) {
 #ifdef HAVE_LANGINFO_H
 			// try to autodetect system encoding
@@ -294,106 +294,106 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			return encoding;
 		});
 	p.add("playlist_disable_highlight_delay", &playlist_disable_highlight_delay,
-	      "5", [](std::string v) {
-		      return boost::posix_time::seconds(verbose_lexical_cast<unsigned>(v));
-	      });
+		  "5", [](std::string v) {
+			  return boost::posix_time::seconds(verbose_lexical_cast<unsigned>(v));
+		  });
 	p.add("message_delay_time", &message_delay_time, "5");
 	p.add("song_list_format", &song_list_format,
-	      "{%a - }{%t}|{$8%f$9}$R{$3%l$9}", [](std::string v) {
-		      return Format::parse(v);
-	      });
+		  "{%a - }{%t}|{$8%f$9}$R{$3%l$9}", [](std::string v) {
+			  return Format::parse(v);
+		  });
 	p.add("song_status_format", &song_status_format,
-	      "{{%a{ \"%b\"{ (%y)}} - }{%t}}|{%f}", [this](std::string v) {
-		      auto flags = Format::Flags::All ^ Format::Flags::OutputSwitch;
-		      // precompute wide format for status display
-		      song_status_wformat = Format::parse(ToWString(v), flags);
-		      return Format::parse(v, flags);
+		  "{{%a{ \"%b\"{ (%y)}} - }{%t}}|{%f}", [this](std::string v) {
+			  auto flags = Format::Flags::All ^ Format::Flags::OutputSwitch;
+			  // precompute wide format for status display
+			  song_status_wformat = Format::parse(ToWString(v), flags);
+			  return Format::parse(v, flags);
 	});
 	p.add("song_library_format", &song_library_format,
-	      "{%n - }{%t}|{%f}", [](std::string v) {
-		      return Format::parse(v);
-	      });
+		  "{%n - }{%t}|{%f}", [](std::string v) {
+			  return Format::parse(v);
+		  });
 	p.add("alternative_header_first_line_format", &new_header_first_line,
-	      "$b$1$aqqu$/a$9 {%t}|{%f} $1$atqq$/a$9$/b", [](std::string v) {
-		      return Format::parse(ToWString(std::move(v)),
-		                           Format::Flags::All ^ Format::Flags::OutputSwitch);
+		  "$b$1$aqqu$/a$9 {%t}|{%f} $1$atqq$/a$9$/b", [](std::string v) {
+			  return Format::parse(ToWString(std::move(v)),
+								   Format::Flags::All ^ Format::Flags::OutputSwitch);
 	});
 	p.add("alternative_header_second_line_format", &new_header_second_line,
-	      "{{$4$b%a$/b$9}{ - $7%b$9}{ ($4%y$9)}}|{%D}", [](std::string v) {
-		      return Format::parse(ToWString(std::move(v)),
-		                           Format::Flags::All ^ Format::Flags::OutputSwitch);
+		  "{{$4$b%a$/b$9}{ - $7%b$9}{ ($4%y$9)}}|{%D}", [](std::string v) {
+			  return Format::parse(ToWString(std::move(v)),
+								   Format::Flags::All ^ Format::Flags::OutputSwitch);
 	});
 	p.add("current_item_prefix", &current_item_prefix, "$(yellow)$r",
-	      std::bind(buffer_wlength,
-	                &current_item_prefix,
-	                std::ref(current_item_prefix_length),
-	                ph::_1));
+		  std::bind(buffer_wlength,
+					&current_item_prefix,
+					std::ref(current_item_prefix_length),
+					ph::_1));
 	p.add("current_item_suffix", &current_item_suffix, "$/r$(end)",
-	      std::bind(buffer_wlength,
-	                &current_item_suffix,
-	                std::ref(current_item_suffix_length),
-	                ph::_1));
+		  std::bind(buffer_wlength,
+					&current_item_suffix,
+					std::ref(current_item_suffix_length),
+					ph::_1));
 	p.add("current_item_inactive_column_prefix", &current_item_inactive_column_prefix,
-	      "$(white)$r",
-	      std::bind(buffer_wlength,
-	                &current_item_inactive_column_prefix,
-	                std::ref(current_item_inactive_column_prefix_length),
-	                ph::_1));
+		  "$(white)$r",
+		  std::bind(buffer_wlength,
+					&current_item_inactive_column_prefix,
+					std::ref(current_item_inactive_column_prefix_length),
+					ph::_1));
 	p.add("current_item_inactive_column_suffix", &current_item_inactive_column_suffix,
-	      "$/r$(end)",
-	      std::bind(buffer_wlength,
-	                &current_item_inactive_column_suffix,
-	                std::ref(current_item_inactive_column_suffix_length),
-	                ph::_1));
+		  "$/r$(end)",
+		  std::bind(buffer_wlength,
+					&current_item_inactive_column_suffix,
+					std::ref(current_item_inactive_column_suffix_length),
+					ph::_1));
 	p.add("now_playing_prefix", &now_playing_prefix, "$b",
-	      std::bind(buffer_wlength,
-	                nullptr,
-	                std::ref(now_playing_prefix_length),
-	                ph::_1));
+		  std::bind(buffer_wlength,
+					nullptr,
+					std::ref(now_playing_prefix_length),
+					ph::_1));
 	p.add("now_playing_suffix", &now_playing_suffix, "$/b",
-	      std::bind(buffer_wlength,
-	                nullptr,
-	                std::ref(now_playing_suffix_length),
-	                ph::_1));
+		  std::bind(buffer_wlength,
+					nullptr,
+					std::ref(now_playing_suffix_length),
+					ph::_1));
 	p.add("browser_playlist_prefix", &browser_playlist_prefix, "$2playlist$9 ", buffer);
 	p.add("selected_item_prefix", &selected_item_prefix, "$6",
-	      std::bind(buffer_wlength,
-	                nullptr,
-	                std::ref(selected_item_prefix_length),
-	                ph::_1));
+		  std::bind(buffer_wlength,
+					nullptr,
+					std::ref(selected_item_prefix_length),
+					ph::_1));
 	p.add("selected_item_suffix", &selected_item_suffix, "$9",
-	      std::bind(buffer_wlength,
-	                nullptr,
-	                std::ref(selected_item_suffix_length),
-	                ph::_1));
+		  std::bind(buffer_wlength,
+					nullptr,
+					std::ref(selected_item_suffix_length),
+					ph::_1));
 	p.add("modified_item_prefix", &modified_item_prefix, "$3>$9 ", buffer);
 	p.add("song_window_title_format", &song_window_title_format,
-	      "{%a - }{%t}|{%f}", [](std::string v) {
-		      return Format::parse(v, Format::Flags::Tag);
-	      });
+		  "{%a - }{%t}|{%f}", [](std::string v) {
+			  return Format::parse(v, Format::Flags::Tag);
+		  });
 	p.add("browser_sort_mode", &browser_sort_mode, "type", [](std::string v) {
 		if (v == "noop")
 		{
 			deprecated("browser_sort_mode = 'noop'",
-			           "0.10",
-			           "use 'none' instead");
+					   "0.10",
+					   "use 'none' instead");
 			v = "none";
 		}
 		return verbose_lexical_cast<SortMode>(v);
 	});
 	p.add("browser_sort_format", &browser_sort_format,
-	      "{%a - }{%t}|{%f} {%l}", [](std::string v) {
-		      return Format::parse(v, Format::Flags::Tag);
-	      });
+		  "{%a - }{%t}|{%f} {%l}", [](std::string v) {
+			  return Format::parse(v, Format::Flags::Tag);
+		  });
 	p.add("song_columns_list_format", &song_columns_mode_format,
-	      "(20)[]{a} (6f)[green]{NE} (50)[white]{t|f:Title} (20)[cyan]{b} (7f)[magenta]{l}",
-	      [this](std::string v) {
-		      columns = generate_columns(v);
-		      return columns_to_format(columns);
-	      });
+		  "(20)[]{a} (6f)[green]{NE} (50)[white]{t|f:Title} (20)[cyan]{b} (7f)[magenta]{l}",
+		  [this](std::string v) {
+			  columns = generate_columns(v);
+			  return columns_to_format(columns);
+		  });
 	p.add("execute_on_song_change", &execute_on_song_change, "", adjust_path);
 	p.add("execute_on_player_state_change", &execute_on_player_state_change,
-	      "", adjust_path);
+		  "", adjust_path);
 	p.add("playlist_show_mpd_host", &playlist_show_mpd_host, "no", yes_no);
 	p.add("playlist_show_remaining_time", &playlist_show_remaining_time, "no", yes_no);
 	p.add("playlist_shorten_total_times", &playlist_shorten_total_times, "no", yes_no);
@@ -403,7 +403,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("search_engine_display_mode", &search_engine_display_mode, "classic");
 	p.add("playlist_editor_display_mode", &playlist_editor_display_mode, "classic");
 	p.add("discard_colors_if_item_is_selected", &discard_colors_if_item_is_selected,
-	      "yes", yes_no);
+		  "yes", yes_no);
 	p.add("show_duplicate_tags", &MPD::Song::ShowDuplicateTags, "yes", yes_no);
 	p.add("incremental_seeking", &incremental_seeking, "yes", yes_no);
 	p.add("seek_time", &seek_time, "1");
@@ -480,16 +480,16 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	      });
 	p.add("follow_now_playing_lyrics", &now_playing_lyrics, "no", yes_no);
 	p.add("fetch_lyrics_for_current_song_in_background", &fetch_lyrics_in_background,
-	      "no", yes_no);
+		  "no", yes_no);
 	p.add("store_lyrics_in_song_dir", &store_lyrics_in_song_dir, "no", yes_no);
 	p.add("generate_win32_compatible_filenames", &generate_win32_compatible_filenames,
-	      "yes", yes_no);
+		  "yes", yes_no);
 	p.add("allow_for_physical_item_deletion", &allow_for_physical_item_deletion,
-	      "no", yes_no);
+		  "no", yes_no);
 	p.add("lastfm_preferred_language", &lastfm_preferred_language, "en");
 	p.add("space_add_mode", &space_add_mode, "add_remove");
 	p.add("show_hidden_files_in_local_browser", &local_browser_show_hidden_files,
-	      "no", yes_no);
+		  "no", yes_no);
 	p.add<void>(
 		"screen_switcher_mode", nullptr, "playlist, browser",
 		[this](std::string v) {
@@ -524,9 +524,9 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 		});
 	p.add("startup_slave_screen_focus", &startup_slave_screen_focus, "no", yes_no);
 	p.add("locked_screen_width_part", &locked_screen_width_part,
-	      "50", [](std::string v) {
-		      return verbose_lexical_cast<double>(v) / 100;
-	      });
+		  "50", [](std::string v) {
+			  return verbose_lexical_cast<double>(v) / 100;
+		  });
 	p.add("ask_for_locked_screen_width_part", &ask_for_locked_screen_width_part,
 	      "yes", yes_no);
 	p.add("media_library_column_width_ratio_two", &media_library_column_width_ratio_two,
@@ -536,11 +536,11 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("playlist_editor_column_width_ratio", &playlist_editor_column_width_ratio,
 			"1:2", std::bind(parse_ratio, ph::_1, 2));
 	p.add("jump_to_now_playing_song_at_start", &jump_to_now_playing_song_at_start,
-	      "yes", yes_no);
+		  "yes", yes_no);
 	p.add("ask_before_clearing_playlists", &ask_before_clearing_playlists,
-	      "yes", yes_no);
+		  "yes", yes_no);
 	p.add("ask_before_shuffling_playlists", &ask_before_shuffling_playlists,
-	      "yes", yes_no);
+		  "yes", yes_no);
 	p.add("clock_display_seconds", &clock_display_seconds, "no", yes_no);
 	p.add("display_volume_level", &display_volume_level, "yes", yes_no);
 	p.add("display_bitrate", &display_bitrate, "no", yes_no);
@@ -561,7 +561,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("ignore_leading_the", &ignore_leading_the, "no", yes_no);
 	p.add("ignore_diacritics", &ignore_diacritics, "no", yes_no);
 	p.add("block_search_constraints_change_if_items_found",
-	      &block_search_constraints_change, "yes", yes_no);
+		  &block_search_constraints_change, "yes", yes_no);
 	p.add("mouse_support", &mouse_support, "yes", yes_no);
 	p.add("mouse_list_scroll_whole_page", &mouse_list_scroll_whole_page, "no", yes_no);
 	p.add("lines_scrolled", &lines_scrolled, "5");
@@ -574,8 +574,8 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			// in emacs terminal nor tty (through any wrapper like screen).
 			auto term = getenv("TERM");
 			if (term != nullptr
-			    && strstr(term, "linux") == nullptr
-			    && strncmp(term, "eterm", const_strlen("eterm")))
+				&& strstr(term, "linux") == nullptr
+				&& strncmp(term, "eterm", const_strlen("eterm")))
 				return yes_no(v);
 			else
 			{
@@ -584,11 +584,11 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			}
 		});
 	p.add("search_engine_default_search_mode", &search_engine_default_search_mode,
-	      "1", [](std::string v) {
-		      auto mode = verbose_lexical_cast<unsigned>(v);
-		      boundsCheck<unsigned>(mode, 1, 3);
-		      return --mode;
-	      });
+		  "1", [](std::string v) {
+			  auto mode = verbose_lexical_cast<unsigned>(v);
+			  boundsCheck<unsigned>(mode, 1, 3);
+			  return --mode;
+		  });
 	p.add("external_editor", &external_editor, "nano", adjust_path);
 	p.add("use_console_editor", &use_console_editor, "yes", yes_no);
 	p.add("colors_enabled", &colors_enabled, "yes", yes_no);
@@ -608,7 +608,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("alternative_ui_separator_color", &alternative_ui_separator_color, "black:b");
 	p.add("window_border_color", &window_border, "green", verbose_lexical_cast<NC::Color>);
 	p.add("active_window_border", &active_window_border, "red",
-	      verbose_lexical_cast<NC::Color>);
+		  verbose_lexical_cast<NC::Color>);
 
 	return std::all_of(
 		config_paths.begin(),

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -180,8 +180,8 @@ NC::Buffer buffer(const std::string &v)
 }
 
 NC::Buffer buffer_wlength(const NC::Buffer *target,
-						  size_t &wlength,
-						  const std::string &v)
+                          size_t &wlength,
+                          const std::string &v)
 {
 	// Compatibility layer between highlight color and new highlight prefix and
 	// suffix. Basically, for older configurations if highlight color is provided,
@@ -197,11 +197,11 @@ NC::Buffer buffer_wlength(const NC::Buffer *target,
 }
 
 void deprecated(const char *option, const char *version_removal,
-				const std::string &advice)
+                const std::string &advice)
 {
 	std::cerr << "WARNING: Variable '" << option
-			  << "' is deprecated and will be removed in "
-			  << version_removal;
+	          << "' is deprecated and will be removed in "
+	          << version_removal;
 	if (!advice.empty())
 		std::cerr << " (" << advice << ")";
 	std::cerr << ".\n";
@@ -235,9 +235,9 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("visualizer_in_stereo", &visualizer_in_stereo, "yes", yes_no);
 	p.add("visualizer_type", &visualizer_type,
 #ifdef HAVE_FFTW3_H
-		  "spectrum"
+	      "spectrum"
 #else
-		  "ellipse"
+	      "ellipse"
 #endif
 		);
 	p.add("visualizer_look", &visualizer_chars, "●▮", [](std::string s) {
@@ -280,7 +280,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("visualizer_spectrum_log_scale_x", &visualizer_spectrum_log_scale_x, "yes", yes_no);
 	p.add("visualizer_spectrum_log_scale_y", &visualizer_spectrum_log_scale_y, "yes", yes_no);
 	p.add("visualizer_color", &visualizer_colors,
-		  "blue, cyan, green, yellow, magenta, red", list_of<NC::FormattedColor>);
+	      "blue, cyan, green, yellow, magenta, red", list_of<NC::FormattedColor>);
 	p.add("system_encoding", &system_encoding, "", [](std::string encoding) {
 #ifdef HAVE_LANGINFO_H
 			// try to autodetect system encoding
@@ -294,106 +294,106 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			return encoding;
 		});
 	p.add("playlist_disable_highlight_delay", &playlist_disable_highlight_delay,
-		  "5", [](std::string v) {
-			  return boost::posix_time::seconds(verbose_lexical_cast<unsigned>(v));
-		  });
+	      "5", [](std::string v) {
+		      return boost::posix_time::seconds(verbose_lexical_cast<unsigned>(v));
+	      });
 	p.add("message_delay_time", &message_delay_time, "5");
 	p.add("song_list_format", &song_list_format,
-		  "{%a - }{%t}|{$8%f$9}$R{$3%l$9}", [](std::string v) {
-			  return Format::parse(v);
-		  });
+	      "{%a - }{%t}|{$8%f$9}$R{$3%l$9}", [](std::string v) {
+		      return Format::parse(v);
+	      });
 	p.add("song_status_format", &song_status_format,
-		  "{{%a{ \"%b\"{ (%y)}} - }{%t}}|{%f}", [this](std::string v) {
-			  auto flags = Format::Flags::All ^ Format::Flags::OutputSwitch;
-			  // precompute wide format for status display
-			  song_status_wformat = Format::parse(ToWString(v), flags);
-			  return Format::parse(v, flags);
+	      "{{%a{ \"%b\"{ (%y)}} - }{%t}}|{%f}", [this](std::string v) {
+		      auto flags = Format::Flags::All ^ Format::Flags::OutputSwitch;
+		      // precompute wide format for status display
+		      song_status_wformat = Format::parse(ToWString(v), flags);
+		      return Format::parse(v, flags);
 	});
 	p.add("song_library_format", &song_library_format,
-		  "{%n - }{%t}|{%f}", [](std::string v) {
-			  return Format::parse(v);
-		  });
+	      "{%n - }{%t}|{%f}", [](std::string v) {
+		      return Format::parse(v);
+	      });
 	p.add("alternative_header_first_line_format", &new_header_first_line,
-		  "$b$1$aqqu$/a$9 {%t}|{%f} $1$atqq$/a$9$/b", [](std::string v) {
-			  return Format::parse(ToWString(std::move(v)),
-								   Format::Flags::All ^ Format::Flags::OutputSwitch);
+	      "$b$1$aqqu$/a$9 {%t}|{%f} $1$atqq$/a$9$/b", [](std::string v) {
+		      return Format::parse(ToWString(std::move(v)),
+		                           Format::Flags::All ^ Format::Flags::OutputSwitch);
 	});
 	p.add("alternative_header_second_line_format", &new_header_second_line,
-		  "{{$4$b%a$/b$9}{ - $7%b$9}{ ($4%y$9)}}|{%D}", [](std::string v) {
-			  return Format::parse(ToWString(std::move(v)),
-								   Format::Flags::All ^ Format::Flags::OutputSwitch);
+	      "{{$4$b%a$/b$9}{ - $7%b$9}{ ($4%y$9)}}|{%D}", [](std::string v) {
+		      return Format::parse(ToWString(std::move(v)),
+		                           Format::Flags::All ^ Format::Flags::OutputSwitch);
 	});
 	p.add("current_item_prefix", &current_item_prefix, "$(yellow)$r",
-		  std::bind(buffer_wlength,
-					&current_item_prefix,
-					std::ref(current_item_prefix_length),
-					ph::_1));
+	      std::bind(buffer_wlength,
+	                &current_item_prefix,
+	                std::ref(current_item_prefix_length),
+	                ph::_1));
 	p.add("current_item_suffix", &current_item_suffix, "$/r$(end)",
-		  std::bind(buffer_wlength,
-					&current_item_suffix,
-					std::ref(current_item_suffix_length),
-					ph::_1));
+	      std::bind(buffer_wlength,
+	                &current_item_suffix,
+	                std::ref(current_item_suffix_length),
+	                ph::_1));
 	p.add("current_item_inactive_column_prefix", &current_item_inactive_column_prefix,
-		  "$(white)$r",
-		  std::bind(buffer_wlength,
-					&current_item_inactive_column_prefix,
-					std::ref(current_item_inactive_column_prefix_length),
-					ph::_1));
+	      "$(white)$r",
+	      std::bind(buffer_wlength,
+	                &current_item_inactive_column_prefix,
+	                std::ref(current_item_inactive_column_prefix_length),
+	                ph::_1));
 	p.add("current_item_inactive_column_suffix", &current_item_inactive_column_suffix,
-		  "$/r$(end)",
-		  std::bind(buffer_wlength,
-					&current_item_inactive_column_suffix,
-					std::ref(current_item_inactive_column_suffix_length),
-					ph::_1));
+	      "$/r$(end)",
+	      std::bind(buffer_wlength,
+	                &current_item_inactive_column_suffix,
+	                std::ref(current_item_inactive_column_suffix_length),
+	                ph::_1));
 	p.add("now_playing_prefix", &now_playing_prefix, "$b",
-		  std::bind(buffer_wlength,
-					nullptr,
-					std::ref(now_playing_prefix_length),
-					ph::_1));
+	      std::bind(buffer_wlength,
+	                nullptr,
+	                std::ref(now_playing_prefix_length),
+	                ph::_1));
 	p.add("now_playing_suffix", &now_playing_suffix, "$/b",
-		  std::bind(buffer_wlength,
-					nullptr,
-					std::ref(now_playing_suffix_length),
-					ph::_1));
+	      std::bind(buffer_wlength,
+	                nullptr,
+	                std::ref(now_playing_suffix_length),
+	                ph::_1));
 	p.add("browser_playlist_prefix", &browser_playlist_prefix, "$2playlist$9 ", buffer);
 	p.add("selected_item_prefix", &selected_item_prefix, "$6",
-		  std::bind(buffer_wlength,
-					nullptr,
-					std::ref(selected_item_prefix_length),
-					ph::_1));
+	      std::bind(buffer_wlength,
+	                nullptr,
+	                std::ref(selected_item_prefix_length),
+	                ph::_1));
 	p.add("selected_item_suffix", &selected_item_suffix, "$9",
-		  std::bind(buffer_wlength,
-					nullptr,
-					std::ref(selected_item_suffix_length),
-					ph::_1));
+	      std::bind(buffer_wlength,
+	                nullptr,
+	                std::ref(selected_item_suffix_length),
+	                ph::_1));
 	p.add("modified_item_prefix", &modified_item_prefix, "$3>$9 ", buffer);
 	p.add("song_window_title_format", &song_window_title_format,
-		  "{%a - }{%t}|{%f}", [](std::string v) {
-			  return Format::parse(v, Format::Flags::Tag);
-		  });
+	      "{%a - }{%t}|{%f}", [](std::string v) {
+		      return Format::parse(v, Format::Flags::Tag);
+	      });
 	p.add("browser_sort_mode", &browser_sort_mode, "type", [](std::string v) {
 		if (v == "noop")
 		{
 			deprecated("browser_sort_mode = 'noop'",
-					   "0.10",
-					   "use 'none' instead");
+			           "0.10",
+			           "use 'none' instead");
 			v = "none";
 		}
 		return verbose_lexical_cast<SortMode>(v);
 	});
 	p.add("browser_sort_format", &browser_sort_format,
-		  "{%a - }{%t}|{%f} {%l}", [](std::string v) {
-			  return Format::parse(v, Format::Flags::Tag);
-		  });
+	      "{%a - }{%t}|{%f} {%l}", [](std::string v) {
+		      return Format::parse(v, Format::Flags::Tag);
+	      });
 	p.add("song_columns_list_format", &song_columns_mode_format,
-		  "(20)[]{a} (6f)[green]{NE} (50)[white]{t|f:Title} (20)[cyan]{b} (7f)[magenta]{l}",
-		  [this](std::string v) {
-			  columns = generate_columns(v);
-			  return columns_to_format(columns);
-		  });
+	      "(20)[]{a} (6f)[green]{NE} (50)[white]{t|f:Title} (20)[cyan]{b} (7f)[magenta]{l}",
+	      [this](std::string v) {
+		      columns = generate_columns(v);
+		      return columns_to_format(columns);
+	      });
 	p.add("execute_on_song_change", &execute_on_song_change, "", adjust_path);
 	p.add("execute_on_player_state_change", &execute_on_player_state_change,
-		  "", adjust_path);
+	      "", adjust_path);
 	p.add("playlist_show_mpd_host", &playlist_show_mpd_host, "no", yes_no);
 	p.add("playlist_show_remaining_time", &playlist_show_remaining_time, "no", yes_no);
 	p.add("playlist_shorten_total_times", &playlist_shorten_total_times, "no", yes_no);
@@ -403,7 +403,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("search_engine_display_mode", &search_engine_display_mode, "classic");
 	p.add("playlist_editor_display_mode", &playlist_editor_display_mode, "classic");
 	p.add("discard_colors_if_item_is_selected", &discard_colors_if_item_is_selected,
-		  "yes", yes_no);
+	      "yes", yes_no);
 	p.add("show_duplicate_tags", &MPD::Song::ShowDuplicateTags, "yes", yes_no);
 	p.add("incremental_seeking", &incremental_seeking, "yes", yes_no);
 	p.add("seek_time", &seek_time, "1");
@@ -480,16 +480,16 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	      });
 	p.add("follow_now_playing_lyrics", &now_playing_lyrics, "no", yes_no);
 	p.add("fetch_lyrics_for_current_song_in_background", &fetch_lyrics_in_background,
-		  "no", yes_no);
+	      "no", yes_no);
 	p.add("store_lyrics_in_song_dir", &store_lyrics_in_song_dir, "no", yes_no);
 	p.add("generate_win32_compatible_filenames", &generate_win32_compatible_filenames,
-		  "yes", yes_no);
+	      "yes", yes_no);
 	p.add("allow_for_physical_item_deletion", &allow_for_physical_item_deletion,
-		  "no", yes_no);
+	      "no", yes_no);
 	p.add("lastfm_preferred_language", &lastfm_preferred_language, "en");
 	p.add("space_add_mode", &space_add_mode, "add_remove");
 	p.add("show_hidden_files_in_local_browser", &local_browser_show_hidden_files,
-		  "no", yes_no);
+	      "no", yes_no);
 	p.add<void>(
 		"screen_switcher_mode", nullptr, "playlist, browser",
 		[this](std::string v) {
@@ -524,9 +524,9 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 		});
 	p.add("startup_slave_screen_focus", &startup_slave_screen_focus, "no", yes_no);
 	p.add("locked_screen_width_part", &locked_screen_width_part,
-		  "50", [](std::string v) {
-			  return verbose_lexical_cast<double>(v) / 100;
-		  });
+	      "50", [](std::string v) {
+		      return verbose_lexical_cast<double>(v) / 100;
+	      });
 	p.add("ask_for_locked_screen_width_part", &ask_for_locked_screen_width_part,
 	      "yes", yes_no);
 	p.add("media_library_column_width_ratio_two", &media_library_column_width_ratio_two,
@@ -536,11 +536,11 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("playlist_editor_column_width_ratio", &playlist_editor_column_width_ratio,
 			"1:2", std::bind(parse_ratio, ph::_1, 2));
 	p.add("jump_to_now_playing_song_at_start", &jump_to_now_playing_song_at_start,
-		  "yes", yes_no);
+	      "yes", yes_no);
 	p.add("ask_before_clearing_playlists", &ask_before_clearing_playlists,
-		  "yes", yes_no);
+	      "yes", yes_no);
 	p.add("ask_before_shuffling_playlists", &ask_before_shuffling_playlists,
-		  "yes", yes_no);
+	      "yes", yes_no);
 	p.add("clock_display_seconds", &clock_display_seconds, "no", yes_no);
 	p.add("display_volume_level", &display_volume_level, "yes", yes_no);
 	p.add("display_bitrate", &display_bitrate, "no", yes_no);
@@ -561,7 +561,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("ignore_leading_the", &ignore_leading_the, "no", yes_no);
 	p.add("ignore_diacritics", &ignore_diacritics, "no", yes_no);
 	p.add("block_search_constraints_change_if_items_found",
-		  &block_search_constraints_change, "yes", yes_no);
+	      &block_search_constraints_change, "yes", yes_no);
 	p.add("mouse_support", &mouse_support, "yes", yes_no);
 	p.add("mouse_list_scroll_whole_page", &mouse_list_scroll_whole_page, "no", yes_no);
 	p.add("lines_scrolled", &lines_scrolled, "5");
@@ -574,8 +574,8 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			// in emacs terminal nor tty (through any wrapper like screen).
 			auto term = getenv("TERM");
 			if (term != nullptr
-				&& strstr(term, "linux") == nullptr
-				&& strncmp(term, "eterm", const_strlen("eterm")))
+			    && strstr(term, "linux") == nullptr
+			    && strncmp(term, "eterm", const_strlen("eterm")))
 				return yes_no(v);
 			else
 			{
@@ -584,11 +584,11 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			}
 		});
 	p.add("search_engine_default_search_mode", &search_engine_default_search_mode,
-		  "1", [](std::string v) {
-			  auto mode = verbose_lexical_cast<unsigned>(v);
-			  boundsCheck<unsigned>(mode, 1, 3);
-			  return --mode;
-		  });
+	      "1", [](std::string v) {
+		      auto mode = verbose_lexical_cast<unsigned>(v);
+		      boundsCheck<unsigned>(mode, 1, 3);
+		      return --mode;
+	      });
 	p.add("external_editor", &external_editor, "nano", adjust_path);
 	p.add("use_console_editor", &use_console_editor, "yes", yes_no);
 	p.add("colors_enabled", &colors_enabled, "yes", yes_no);
@@ -608,7 +608,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("alternative_ui_separator_color", &alternative_ui_separator_color, "black:b");
 	p.add("window_border_color", &window_border, "green", verbose_lexical_cast<NC::Color>);
 	p.add("active_window_border", &active_window_border, "red",
-		  verbose_lexical_cast<NC::Color>);
+	      verbose_lexical_cast<NC::Color>);
 
 	return std::all_of(
 		config_paths.begin(),

--- a/src/settings.h
+++ b/src/settings.h
@@ -90,8 +90,8 @@ struct Configuration
 	double visualizer_spectrum_gain;
 	double visualizer_spectrum_hz_min;
 	double visualizer_spectrum_hz_max;
-    bool visualizer_spectrum_log_scale_x;
-    bool visualizer_spectrum_log_scale_y;
+	bool visualizer_spectrum_log_scale_x;
+	bool visualizer_spectrum_log_scale_y;
 
 	std::string pattern;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -90,6 +90,8 @@ struct Configuration
 	double visualizer_spectrum_gain;
 	double visualizer_spectrum_hz_min;
 	double visualizer_spectrum_hz_max;
+    bool visualizer_spectrum_log_scale_x;
+    bool visualizer_spectrum_log_scale_y;
 
 	std::string pattern;
 


### PR DESCRIPTION
Brings back the linear(-ish) axis scaling from pre-0.9.x (see #453) while keeping DFT adjustments made in #397 and adding config options `visualizer_spectrum_log_scale_x` and `visualizer_spectrum_log_scale_y` for log scaling on either/both axes.

Also switches the character used for the sound ellipse to `Config.visualizer_chars[0]` from `Config.visualizer_chars[1]` (by default this is the round character rather than the bar) because I thought it looked silly otherwise.

Here's a sample of what the linear scaling looks like in my terminal:
![2021-03-18-003020](https://user-images.githubusercontent.com/15965124/112113297-a11e6600-8b84-11eb-869b-48e8dd2a0227.png)
and with `visualizer_smooth_look = yes`:
![2021-03-23-031044](https://user-images.githubusercontent.com/15965124/112113923-71bc2900-8b85-11eb-97da-e9dd71bf20d7.png)

A couple additional notes:
- I noticed that the cubic interpolation used with log-scaling caused a problem when linear-scaling where the leftmost column would not be cropped properly and instead wrap onto the top/bottom edges of the drawing area:
  ![2021-03-23-031515](https://user-images.githubusercontent.com/15965124/112114746-67e6f580-8b86-11eb-840a-099a7ca69757.png)
  This usually isn't a problem with log scaling because the DFT always goes to zero at those low frequencies (assuming small enough `visualizer_spectrum_hz_min`), but here it's quite bothersome, so when doing x-axis linear scaling, I set the height for bins not directly computed by the DFT to zero rather than interpolate, since I think it's not needed in this case anyway.
- `visualizer_spectrum_gain` is still in dB, for consistency with the `visualizer_spectrum_log_scale_y = yes` case. The constants setting the vertical scale are set to my personal preference for default `gain = 10` and are slightly adjusted compared to pre-0.9.x (slightly less high-frequency boost).
