### PR TITLE
Improve specrum visulaizer for transparent backgrounds

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -125,6 +125,15 @@
 #
 #visualizer_spectrum_smooth_look = yes
 #
+## Use unicode block characters from "symbols for legacy computing", this
+## improves the smooth look on transparent terminals by using special unicode
+## chars instead of reversing the background and foreground color on the bottom
+## edge of the spectrum. This may lead to a glitchy mess on the bottom edge of
+## the spectrum, this can eighter be fixed by changing the font or disabeling
+## this.
+#
+#visualizer_spectrum_use_legacy_chars = yes
+#
 ## A value between 1 and 5 inclusive. Specifying a larger value makes the
 ## visualizer look at a larger slice of time, which results in less jumpy
 ## visualizer output.

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -114,6 +114,9 @@ Automatically scale visualizer size.
 .B visualizer_spectrum_smooth_look = yes/no
 For spectrum visualizer, use unicode block characters for a smoother, more continuous look. This will override the visualizer_look option. With transparent terminals and visualizer_in_stereo set, artifacts may be visible on the bottom half of the visualization.
 .TP
+.B visualizer_spectrum_use_legacy_chars = yes/no
+Use unicode block characters from "symbols for legacy computing", this improves the smooth look on transparent terminals by using special unicode chars instead of reversing the background and foreground color on the bottom edge of the spectrum. This may lead to a glitchy mess on the bottom edge of the spectrum, this can eighter be fixed by changing the font or disabeling this.
+.TP
 .B visualizer_spectrum_dft_size = NUMBER
 For spectrum visualizer, a value between 1 and 5 inclusive. Specifying a larger value makes the visualizer look at a larger slice of time, which results in less jumpy visualizer output.
 .TP

--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -519,7 +519,12 @@ void Visualizer::DrawFrequencySpectrum(const int16_t *buf, ssize_t samples, size
 				} else {
 					// fractional height
 					if (flipped) {
-						ch = SMOOTH_CHARS_FLIPPED[idx];
+						if (Config.visualizer_spectrum_use_legacy_chars) {
+							ch = SMOOTH_CHARS_FLIPPED[idx];
+						} else {
+							ch = SMOOTH_CHARS[size-idx-2];
+							color = NC::FormattedColor(color.color(), {NC::Format::Reverse});
+						}
 					} else {
 						ch = SMOOTH_CHARS[idx];
 					}

--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -83,7 +83,8 @@ Visualizer::Visualizer()
   HZ_MIN(Config.visualizer_spectrum_hz_min),
   HZ_MAX(Config.visualizer_spectrum_hz_max),
   GAIN(Config.visualizer_spectrum_gain),
-  SMOOTH_CHARS(ToWString("▁▂▃▄▅▆▇█"))
+  SMOOTH_CHARS(ToWString(        "▁▂▃▄▅▆▇█")),
+  SMOOTH_CHARS_FLIPPED(ToWString("▔🮂🮃🮄🬎🮅🮆█")) // https://unicode.org/charts/PDF/U1FB00.pdf
 #endif
 {
 	InitDataSource();
@@ -518,8 +519,7 @@ void Visualizer::DrawFrequencySpectrum(const int16_t *buf, ssize_t samples, size
 				} else {
 					// fractional height
 					if (flipped) {
-						ch = SMOOTH_CHARS[size-idx-2];
-						color = NC::FormattedColor(color.color(), {NC::Format::Reverse});
+						ch = SMOOTH_CHARS_FLIPPED[idx];
 					} else {
 						ch = SMOOTH_CHARS[idx];
 					}

--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -83,7 +83,7 @@ Visualizer::Visualizer()
   HZ_MIN(Config.visualizer_spectrum_hz_min),
   HZ_MAX(Config.visualizer_spectrum_hz_max),
   GAIN(Config.visualizer_spectrum_gain),
-  SMOOTH_CHARS(ToWString(        "▁▂▃▄▅▆▇█")),
+  SMOOTH_CHARS(ToWString("▁▂▃▄▅▆▇█")),
   SMOOTH_CHARS_FLIPPED(ToWString("▔🮂🮃🮄🬎🮅🮆█")) // https://unicode.org/charts/PDF/U1FB00.pdf
 #endif
 {

--- a/src/screens/visualizer.h
+++ b/src/screens/visualizer.h
@@ -113,6 +113,7 @@ private:
 	const double HZ_MAX;
 	const double GAIN;
 	const std::wstring SMOOTH_CHARS;
+	const std::wstring SMOOTH_CHARS_FLIPPED;
 	std::vector<double> m_dft_logspace;
 	std::vector<std::pair<size_t, double>> m_bar_heights;
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -275,6 +275,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 			});
 	p.add("visualizer_autoscale", &visualizer_autoscale, "no", yes_no);
 	p.add("visualizer_spectrum_smooth_look", &visualizer_spectrum_smooth_look, "yes", yes_no);
+	p.add("visualizer_spectrum_use_legacy_chars", &visualizer_spectrum_use_legacy_chars, "yes", yes_no);
 	p.add("visualizer_spectrum_dft_size", &visualizer_spectrum_dft_size,
 			"2", [](std::string v) {
 			auto result = verbose_lexical_cast<size_t>(v);

--- a/src/settings.h
+++ b/src/settings.h
@@ -86,6 +86,7 @@ struct Configuration
 	size_t visualizer_fps;
 	bool visualizer_autoscale;
 	bool visualizer_spectrum_smooth_look;
+	bool visualizer_spectrum_use_legacy_chars;
 	uint32_t visualizer_spectrum_dft_size;
 	double visualizer_spectrum_gain;
 	double visualizer_spectrum_hz_min;


### PR DESCRIPTION
I replaced the previous flipping method with chars I found in [Symbols for Legacy Computing](https://unicode.org/charts/PDF/U1FB00.pdf). This improves the spectrum visualizer when viewed in a terminal with a transparent background.

old:
![screenshot_1617751540](https://user-images.githubusercontent.com/18621411/113789828-394d4b00-9740-11eb-8dab-71a4620cbdca.png)
new:
![screenshot_1617751531](https://user-images.githubusercontent.com/18621411/113789830-39e5e180-9740-11eb-9f1b-20d70db04a93.png)
(Both tested in kitty)
