### PR TITLE
Fix separator between albums with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ncmpcpp-0.10 (????-??-??)
 * Add the configuration option `mpd_password`.
 * Separate chunks of lyrics with a double newline.
+* Fix separator between albums with the same name, to check for album artist
+  instead of artist.
 
 # ncmpcpp-0.9.2 (2021-01-24)
 * Revert suppression of output of all external commands as that makes e.g album

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -92,9 +92,9 @@ void setProperties(NC::Menu<T> &menu, const MPD::Song &s, const SongList &list,
 			{
 				// Draw a separator when the next album is different than the current
 				// one. In case there are two albums with the same name, but a different
-				// artist, compare also artists.
+				// album artist, compare also album artists.
 				separate_albums = next->song()->getAlbum() != s.getAlbum()
-				               || next->song()->getArtist() != s.getArtist();
+				               || next->song()->getAlbumArtist() != s.getAlbumArtist();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes the separator between albums of the same name introduced in [`89ebfbf`](https://github.com/ncmpcpp/ncmpcpp/commit/89ebfbf73dbf68221de4e735ea75c4e7a4a7bf10), as it visually splits up an album if the artist changes. Which means that every track with a feature get a separator above and below:

![screenshot_21-04-21_14:58:20](https://user-images.githubusercontent.com/25589715/115560197-a6bab900-a2b4-11eb-953c-3fcc8c166ec9.png)

I changed the check to compare album artists instead, which are consistent across the whole album.

fixes #455 