### PR TITLE
Fix overflow errors and allow small terminal sizes

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -124,18 +124,6 @@ size_t HeaderHeight;
 size_t FooterHeight;
 size_t FooterStartY;
 
-void validateScreenSize()
-{
-	using Global::MainHeight;
-	
-	if (COLS < 30 || MainHeight < 5)
-	{
-		NC::destroyScreen();
-		std::cout << "Screen is too small to handle ncmpcpp correctly\n";
-		exit(1);
-	}
-}
-
 void initializeScreens()
 {
 	myHelp = new Help;
@@ -220,8 +208,6 @@ void resizeScreen(bool reload_main_window)
 	}
 
 	MainHeight = std::max(LINES-(Config.design == Design::Alternative ? 7 : 4), 0);
-
-	validateScreenSize();
 
 	if (!Config.header_visibility)
 		MainHeight += 2;

--- a/src/curses/window.cpp
+++ b/src/curses/window.cpp
@@ -682,13 +682,16 @@ void Window::moveTo(size_t new_x, size_t new_y)
 
 void Window::adjustDimensions(size_t width, size_t height)
 {
+	// NOTE: when dimensions get small, integer overflow will cause calls to
+	// `Menu<T>::refresh()` to run for a very long time.
+
 	if (m_border)
 	{
-		width -= 2;
-		height -= 2;
+		width -= width >= 2 ? 2 : 0;
+		height -= height >= 2 ? 2 : 0;
 	}
 	if (!m_title.empty())
-		height -= 2;
+		height -= height >= 2 ? 2 : 0;
 	m_height = height;
 	m_width = width;
 }


### PR DESCRIPTION
* In #259 users request the ability to have ncmpcpp remain open when the
  terminal has a small size. Previously ncmpcpp would exit when there
  were less than 30 columns or 5 rows.
* After removing this constraint, ncmpcpp would freeze when terminal
  sizes went below those thresholds.
* Upon debugging, it became clear that ncmpcpp wasn't frozen, it was
  stuck in a very long for loop because it thought the display was
  unreasonably large (resulting from integer overflow).
* Preventing that overflow allows ncmpcpp to handle small sizes
  gracefully. No other changes to the rendering code were necessary.

Fixes #259