### PR TITLE
Add tags lyrics fetcher

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -32,6 +32,7 @@
 #include "mpdpp.h"
 #include "format_impl.h"
 #include "settings.h"
+#include "song.h"
 #include "utility/string.h"
 
 namespace po = boost::program_options;
@@ -175,7 +176,8 @@ bool configure(int argc, char **argv)
 				          << fetcher->name()
 				          << " : "
 				          << std::flush;
-				auto result = fetcher->fetch(std::get<1>(data), std::get<2>(data));
+				// The nullptr is a bit hacky, but that argument is only used by the tags fetchers and it is not being tested
+				auto result = fetcher->fetch(std::get<1>(data), std::get<2>(data), nullptr);
 				std::cout << (result.first ? "ok" : "failed")
 				          << "\n";
 			}

--- a/src/lyrics_fetcher.h
+++ b/src/lyrics_fetcher.h
@@ -23,6 +23,8 @@
 
 #include "config.h"
 
+#include <song.h>
+
 #include <memory>
 #include <string>
 
@@ -33,7 +35,7 @@ struct LyricsFetcher
 	virtual ~LyricsFetcher() { }
 
 	virtual const char *name() const = 0;
-	virtual Result fetch(const std::string &artist, const std::string &title);
+	virtual Result fetch(const std::string &artist, const std::string &title, const MPD::Song &song);
 	
 protected:
 	virtual const char *urlTemplate() const = 0;
@@ -57,7 +59,7 @@ std::istream &operator>>(std::istream &is, LyricsFetcher_ &fetcher);
 
 struct GoogleLyricsFetcher : public LyricsFetcher
 {
-	virtual Result fetch(const std::string &artist, const std::string &title);
+	virtual Result fetch(const std::string &artist, const std::string &title, const MPD::Song &song);
 	
 protected:
 	virtual const char *urlTemplate() const { return URL; }
@@ -156,7 +158,7 @@ protected:
 struct InternetLyricsFetcher : public GoogleLyricsFetcher
 {
 	virtual const char *name() const override { return "the Internet"; }
-	virtual Result fetch(const std::string &artist, const std::string &title) override;
+	virtual Result fetch(const std::string &artist, const std::string &title, const MPD::Song &song) override;
 	
 protected:
 	virtual const char *siteKeyword() const override { return nullptr; }
@@ -167,5 +169,17 @@ protected:
 private:
 	std::string URL;
 };
+
+#ifdef HAVE_TAGLIB_H
+struct TagsLyricsFetcher : public LyricsFetcher
+{
+	virtual const char *name() const override { return "tags"; }
+	virtual Result fetch(const std::string &artist, const std::string &title, const MPD::Song &song) override;
+
+protected:
+	virtual const char *urlTemplate() const override { return ""; }
+	virtual const char *regex() const override { return ""; }
+};
+#endif // HAVE_TAGLIB_H
 
 #endif // NCMPCPP_LYRICS_FETCHER_H

--- a/src/screens/lyrics.cpp
+++ b/src/screens/lyrics.cpp
@@ -151,7 +151,7 @@ boost::optional<std::string> downloadLyrics(
 				     << NC::Format::NoBold << "... ";
 			}
 		}
-		auto result_ = fetcher_->fetch(s_artist, s_title);
+		auto result_ = fetcher_->fetch(s_artist, s_title, s);
 		if (result_.first == false)
 		{
 			if (shared_buffer)


### PR DESCRIPTION
This adds a new lyrics fetcher that reads the lyrics from the tags.
This implementation follows #440. It implements a new fetcher (like the genius one for example), but the lyrics are still written to a seperate txt file.
It would also be possible to implement this like suggested in #273, replacing the txt file with the lyrics tag. (with configuration parameters to preserve the old behavior)

Before continuing or implementing #273 I'm waiting for feedback.
I'm also not sure if I can find all lyrics tags, I currently only used bandcamp mastered music (flac, ogg, mp3) for testing.