### PR TITLE
Add setting to format now playing song column

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -204,8 +204,9 @@ void showSongsInColumns(NC::Menu<T> &menu, const MPD::Song &s, const SongList &l
 	int y = menu.getY();
 	int remained_width = menu_width;
 
-	std::vector<Column>::const_iterator it, last = Config.columns.end() - 1;
-	for (it = Config.columns.begin(); it != Config.columns.end(); ++it)
+	std::vector<Column> columns = is_now_playing ? Config.now_playing_columns : Config.columns;
+	std::vector<Column>::const_iterator it, last = columns.end() - 1;
+	for (it = columns.begin(); it != columns.end(); ++it)
 	{
 		// check current X coordinate
 		int x = menu.getX();

--- a/src/screens/playlist.cpp
+++ b/src/screens/playlist.cpp
@@ -345,7 +345,10 @@ std::string songToString(const MPD::Song &s)
 			result = Format::stringify<char>(Config.song_list_format, &s);
 			break;
 		case DisplayMode::Columns:
-			result = Format::stringify<char>(Config.song_columns_mode_format, &s);
+			if (Status::State::currentSongPosition() == s.getPosition())
+				result = Format::stringify<char>(Config.song_columns_mode_now_playing_format, &s);
+			else
+				result = Format::stringify<char>(Config.song_columns_mode_format, &s);
 	}
 	return result;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -412,11 +412,19 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 		      return columns_to_format(columns);
 	      });
 	p.add("song_columns_list_now_playing_format", &song_columns_mode_now_playing_format,
-		  // Same as above but with bright color variations
-		  "(20)[16]{a} (6f)[11]{NE} (50)[16]{t|f:Title} (20)[15]{b} (7f)[14]{l}",
+		  // Default will just use song_columns_mode_format
+		  "default",
 		  [this](std::string v) {
-			  now_playing_columns = generate_columns(v);
-			  return columns_to_format(now_playing_columns);
+			  if (v != "default")
+			  {
+				now_playing_columns = generate_columns(v);
+				return columns_to_format(now_playing_columns);
+			  }
+			  else
+			  {
+				now_playing_columns = columns;
+				return song_columns_mode_format;
+			  }
 		  });
 	p.add("execute_on_song_change", &execute_on_song_change, "", adjust_path);
 	p.add("execute_on_player_state_change", &execute_on_player_state_change,

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -411,6 +411,13 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 		      columns = generate_columns(v);
 		      return columns_to_format(columns);
 	      });
+	p.add("song_columns_list_now_playing_format", &song_columns_mode_now_playing_format,
+		  // Same as above but with bright color variations
+		  "(20)[16]{a} (6f)[11]{NE} (50)[16]{t|f:Title} (20)[15]{b} (7f)[14]{l}",
+		  [this](std::string v) {
+			  now_playing_columns = generate_columns(v);
+			  return columns_to_format(now_playing_columns);
+		  });
 	p.add("execute_on_song_change", &execute_on_song_change, "", adjust_path);
 	p.add("execute_on_player_state_change", &execute_on_player_state_change,
 	      "", adjust_path);

--- a/src/settings.h
+++ b/src/settings.h
@@ -70,6 +70,7 @@ struct Configuration
 	Format::AST<char> song_window_title_format;
 	Format::AST<char> song_library_format;
 	Format::AST<char> song_columns_mode_format;
+	Format::AST<char> song_columns_mode_now_playing_format;
 	Format::AST<char> browser_sort_format;
 	Format::AST<char> song_status_format;
 	Format::AST<wchar_t> song_status_wformat;
@@ -98,6 +99,7 @@ struct Configuration
 	std::vector<size_t> media_library_column_width_ratio_three;
 
 	std::vector<Column> columns;
+	std::vector<Column> now_playing_columns;
 
 	DisplayMode playlist_display_mode;
 	DisplayMode browser_display_mode;


### PR DESCRIPTION
This adds a setting to allow for users to specify a column formatting for the currently playing song in the playlist.
I think this is what #36's request is.  I came across this "issue" after switching to a new terminal emulator that doesn't 
automatically brighten bold text, and this allows users to get around that and adds some extra functionality.