### PR TITLE
Increase the framerate limit for the visualizer.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -498,7 +498,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add<void>(
 		"screen_switcher_mode", nullptr, "playlist, browser",
 		[this](std::string v) {
-			if (v == "previous")f
+			if (v == "previous")
 				screen_switcher_previous = true;
 			else
 			{

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -270,7 +270,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("visualizer_fps", &visualizer_fps,
 			"60", [](std::string v) {
 			uint32_t result = verbose_lexical_cast<uint32_t>(v);
-			boundsCheck<uint32_t>(result, 30, 144);
+			boundsCheck<uint32_t>(result, 30, 1000);
 			return result;
 			});
 	p.add("visualizer_autoscale", &visualizer_autoscale, "no", yes_no);
@@ -498,7 +498,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add<void>(
 		"screen_switcher_mode", nullptr, "playlist, browser",
 		[this](std::string v) {
-			if (v == "previous")
+			if (v == "previous")f
 				screen_switcher_previous = true;
 			else
 			{


### PR DESCRIPTION
I changed the maximum fps limit from 144 to 1000. I have a 240Hz monitor and today 360Hz monitors are consumer level tech available on the market.

As time goes on monitor refresh rates will keep getting higher and higher so changing this limit to 1000 should be enough for now.