### PR TITLE
Bugfix: read Performer ID3 tag from TPE4, not TPE3

### DIFF
--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -92,7 +92,7 @@ void readID3v2Tags(mpd_song *s, TagLib::ID3v2::Tag *tag)
 	readFrame(frames["TRCK"], "Track");
 	readFrame(frames["TCON"], "Genre");
 	readFrame(frames["TCOM"], "Composer");
-	readFrame(frames["TPE3"], "Performer");
+	readFrame(frames["TPE4"], "Performer");
 	readFrame(frames["TPOS"], "Disc");
 	readFrame(frames["COMM"], "Comment");
 }
@@ -166,7 +166,7 @@ void writeID3v2Tags(const MPD::MutableSong &s, TagLib::ID3v2::Tag *tag)
 	writeID3v2("TRCK", tagList(s, &MPD::Song::getTrack));
 	writeID3v2("TCON", tagList(s, &MPD::Song::getGenre));
 	writeID3v2("TCOM", tagList(s, &MPD::Song::getComposer));
-	writeID3v2("TPE3", tagList(s, &MPD::Song::getPerformer));
+	writeID3v2("TPE4", tagList(s, &MPD::Song::getPerformer));
 	writeID3v2("TPOS", tagList(s, &MPD::Song::getDisc));
 	writeID3v2("COMM", tagList(s, &MPD::Song::getComment));
 }


### PR DESCRIPTION
Fixes issue https://github.com/ncmpcpp/ncmpcpp/issues/468.

Why: mpd recently [changed](https://github.com/MusicPlayerDaemon/MPD/pull/1079/files) its tag definitions, causing a mismatch against ncmpcpp's.  

- Previously, "Performer" could be either TPE3 or TPE4
- Now, TPE3 is assigned to "Conductor" instead (in compliance with the ID3 [standard](https://id3.org/id3v2.3.0))

What: updates definitions to match mpd's, so ncmpcpp can read and write the "Performer" tag without issues.

Haven't tested.