### PR TITLE
Append newline to --current-song output

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -239,7 +239,7 @@ bool configure(int argc, char **argv)
 			if (!s.empty())
 			{
 				auto format = Format::parse(vm["current-song"].as<std::string>(), Format::Flags::Tag);
-				std::cout << Format::stringify<char>(format, &s);
+				std::cout << Format::stringify<char>(format, &s) << '\n';
 			}
 			return false;
 		}


### PR DESCRIPTION
Currently the default behavior is to print information about the current
song without a trailing newline. This can make use in scripts rather
tedious as you need to manually append a newline to the output. This PR
appends a newline to the output which makes life easier for the user.
