### PR TITLE
Fix freeze if the line with playlist_directory is still commented.

### DIFF
--- a/src/screens/playlist_editor.cpp
+++ b/src/screens/playlist_editor.cpp
@@ -169,7 +169,7 @@ void PlaylistEditor::update()
 			}
 			catch (MPD::ServerError &e)
 			{
-				if (e.code() == MPD_SERVER_ERROR_SYSTEM) // no playlists directory
+				if (e.code() == MPD_SERVER_ERROR_SYSTEM || e.code() == MPD_SERVER_ERROR_UNKNOWN_CMD) // no playlists directory || commented line with playlist_directory in mpd.conf
 					Statusbar::print(e.what());
 				else
 					throw;


### PR DESCRIPTION
Fix freeze if the line with _playlist_directory_ is still commented, mentioned in the second part of #147.

If the line with playlist_directory is still commented, mpd throws a server error with the code MPD_SERVER_ERROR_UNKNOWN_CMD (5) which caused ncmpcpp to freeze.