### PR TITLE
implement the oneshot state of single mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Separate chunks of lyrics with a double newline.
 * Fix separator between albums with the same name, to check for album artist
   instead of artist.
+* Implement the oneshot state of single mode.
 
 # ncmpcpp-0.9.2 (2021-01-24)
 * Revert suppression of output of all external commands as that makes e.g album

--- a/doc/bindings
+++ b/doc/bindings
@@ -351,6 +351,9 @@
 #def_key "y"
 #  toggle_single
 #
+#def_key "'"
+#  set_single_oneshot
+#
 #def_key "R"
 #  toggle_consume
 #

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1333,6 +1333,11 @@ void ToggleSingle::run()
 	Mpd.SetSingle(!Status::State::single());
 }
 
+void SetOneshot::run()
+{
+	Mpd.SetOneshot();
+}
+
 void ToggleConsume::run()
 {
 	Mpd.SetConsume(!Status::State::consume());
@@ -2802,6 +2807,7 @@ void populateActions()
 	insert_action(new Actions::StartSearching());
 	insert_action(new Actions::SaveTagChanges());
 	insert_action(new Actions::ToggleSingle());
+	insert_action(new Actions::SetOneshot());
 	insert_action(new Actions::ToggleConsume());
 	insert_action(new Actions::ToggleCrossfade());
 	insert_action(new Actions::SetCrossfade());

--- a/src/actions.h
+++ b/src/actions.h
@@ -94,6 +94,7 @@ enum class Type
 	StartSearching,
 	SaveTagChanges,
 	ToggleSingle,
+	SetOneshot,
 	ToggleConsume,
 	ToggleCrossfade,
 	SetCrossfade,
@@ -761,6 +762,14 @@ struct ToggleSingle: BaseAction
 {
 	ToggleSingle(): BaseAction(Type::ToggleSingle, "toggle_single") { }
 	
+private:
+	virtual void run() override;
+};
+
+struct SetOneshot: BaseAction
+{
+	SetOneshot(): BaseAction(Type::SetOneshot, "set_single_oneshot") { }
+
 private:
 	virtual void run() override;
 };

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -620,6 +620,8 @@ void BindingsConfiguration::generateDefaults()
 		bind(k, Actions::Type::ToggleRepeat);
 	if (notBound(k = stringToKey("z")))
 		bind(k, Actions::Type::ToggleRandom);
+	if (notBound(k = stringToKey("'")))
+		bind(k, Actions::Type::SetOneshot);
 	if (notBound(k = stringToKey("y")))
 	{
 		bind(k, Actions::Type::SaveTagChanges);

--- a/src/mpdpp.cpp
+++ b/src/mpdpp.cpp
@@ -463,6 +463,13 @@ void Connection::SetSingle(bool mode)
 	checkErrors();
 }
 
+void Connection::SetOneshot()
+{
+	prechecksNoCommandsList();
+	mpd_run_single_state(m_connection.get(), MPD_SINGLE_ONESHOT);
+	checkErrors();
+}
+
 void Connection::SetConsume(bool mode)
 {
 	prechecksNoCommandsList();

--- a/src/mpdpp.h
+++ b/src/mpdpp.h
@@ -540,6 +540,7 @@ struct Connection
 	void SetRepeat(bool);
 	void SetRandom(bool);
 	void SetSingle(bool);
+	void SetOneshot();
 	void SetConsume(bool);
 	void SetCrossfade(unsigned);
 	void SetVolume(unsigned int vol);

--- a/src/screens/help.cpp
+++ b/src/screens/help.cpp
@@ -202,6 +202,7 @@ void write_bindings(NC::Scrollpad &w)
 	key(w, Type::ToggleRepeat, "Toggle repeat mode");
 	key(w, Type::ToggleRandom, "Toggle random mode");
 	key(w, Type::ToggleSingle, "Toggle single mode");
+	key(w, Type::SetOneshot, "Activate oneshot single mode");
 	key(w, Type::ToggleConsume, "Toggle consume mode");
 	key(w, Type::ToggleReplayGainMode, "Toggle replay gain mode");
 	key(w, Type::ToggleBitrateVisibility, "Toggle bitrate visibility");


### PR DESCRIPTION
This pull request enables `ncmpcpp` to activate single mode in the oneshot state - that is the single mode is unset once it is executed.

I have implemented this separately from the current system for toggling the single mode and without any indication that the oneshot state is set (it will only show that the single mode is active) - if I should rework it in a unified manner, please suggest how it should behave. Also, the default keybinding is rather arbitrary, let me know if I should change it and what to.
