### PR TITLE
Fix unresponsive stall when server error occurs

### DIFF
--- a/src/screens/playlist_editor.cpp
+++ b/src/screens/playlist_editor.cpp
@@ -169,10 +169,7 @@ void PlaylistEditor::update()
 			}
 			catch (MPD::ServerError &e)
 			{
-				if (e.code() == MPD_SERVER_ERROR_SYSTEM) // no playlists directory
-					Statusbar::print(e.what());
-				else
-					throw;
+				Status::handleServerError(e);
 			}
 			if (idx < Playlists.size())
 				Playlists.resizeList(idx);


### PR DESCRIPTION
Fixes #559, also fixes #539 and fixes #521.

The referenced issue occurs here (Presumably, the unresponsiveness occurs due to the playlist not being properly resized. Regardless, ensuring that the resizing does happen even after an error occurs seems to solve this).

https://github.com/ncmpcpp/ncmpcpp/blob/417d7172e5587f4302f92ea6377268dca7f726ad/src/screens/playlist_editor.cpp#L170-L180

The error code received in the issue is `MPD_SERVER_ERROR_UNKNOWN_CMD`, which fails the if statement, and thus the code throws the error.
The problem here is throwing leaves the remaining code outside of the catch block (which handles the case where the playlist might not have been iterated through fully) unreachable.

The code already appears to be trying to handle `MPD_SERVER_ERROR_SYSTEM` (which in that particular instance is not that different from calling `Status::handleServerError(e)` anyway), so we might as well call that regardless of the error code, while not throwing anything in the process.