### PR TITLE
Fix crash when background-fetching lyrics for streams

### DIFF
--- a/src/song.cpp
+++ b/src/song.cpp
@@ -293,7 +293,9 @@ bool Song::isFromDatabase() const
 bool Song::isStream() const
 {
 	assert(m_song);
-	return !strncmp(mpd_song_get_uri(m_song.get()), "http://", 7);
+	const char *song_uri = mpd_song_get_uri(m_song.get());
+	// Stream schemas: http, https
+	return !strncmp(song_uri, "http://", 7) || !strncmp(song_uri, "https://", 8);
 }
 
 bool Song::empty() const
@@ -308,7 +310,7 @@ std::string Song::ShowTime(unsigned length)
 	int minutes = length/60;
 	length -= minutes*60;
 	int seconds = length;
-	
+
 	std::string result;
 	if (hours > 0)
 		result = (boost::format("%d:%02d:%02d") % hours % minutes % seconds).str();


### PR DESCRIPTION
When `fetch_lyrics_for_current_song_in_background` is set to `yes`, and an HTTP(S) stream is loaded with a long URL, ncmpcpp crashes due to the length of the filename generated to store lyrics. This PR makes the background lyrics fetcher ignore such streams, preventing the crash. Addresses issue #380. Replaces #541; this PR pulls from a specific branch instead of master.

## Crash details
For HTTP(S) streams, `Lyrics::fetchInBackground` makes ncmpcpp crash: the `lyrics_file` gets set to the stream URL, which is too long, hence `boost::filesystem::exists()` fails.

To reproduce the crash
1. Ensure `ncmpcpp` is not running
2. Queue a stream with a long URL in MPD, I use `mpc add "$(yt-dlp -x -g 'https://www.youtube.com/watch?v=DZnDeEjM6j8')"`
    * `yt-dlp` generates a long URL such as `https://rr3---sn-5hnekn7l.googlevideo.com/videoplayback?expire=1651681319&ei=x1NyYo2pDvrZx_AP3J6KsAk&ip=94.157.14.223&id=o-AEAc04bXHcCsDIYPI0-eiwOsAnn8De8M1TUq-P445JGO&itag=251&source=youtube&requiressl=yes&mh=A5&mm=31%2C26&mn=sn-5hnekn7l%2Csn-4g5ednld&ms=au%2Conr&mv=m&mvi=3&pl=20&initcwndbps=2158750&vprv=1&mime=audio%2Fwebm&gir=yes&clen=4588517&dur=278.681&lmt=1450243131281714&mt=1651659411&fvip=5&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRAIgAjCX3waGpU_rh1VYuwgXp0emhG-327XAnWJYf7aexZQCIBphphorV8s0oS_z4BKky-z3_9FOwI5ELJHsa5pqxehH&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRgIhAPUkrxGcv74jJBF510zPYADY8nFdK_kjzy7nCHSnN9NOAiEA--Bq7w_dEzJzG0IZvfaMfljeARxSO9gDga5UqsKOU2Y%3D`
3. Set `fetch_lyrics_for_current_song_in_background` to `yes` in the ncmpcpp config file.
4. Start ncmpcpp. You should observe a crash (edit: you might also need to start playing the stream, e.g. with `mpc play`).

## Discussion of solutions
Possible solutions:
* truncate the URL and use that as a filename. Problem: resulting filename might not be unique.
* generate filenames in a different way for streams. Problem: what is a good method for this? Perhaps hashing -- but then the lyrics filenames are not informative.
* skip fetching lyrics for streams with URLs that are too long. Problem: this leads to inconsistent behavior since lyrics will be fetched for some streams but not others.
* avoid fetching lyrics for streams altogether.

## Conclusion
I chose the last solution, and ignore streams when fetching lyrics. This is because fetching lyrics for a stream may not be accurate (streams do not always provide the necessary metadata to look up lyrics reliably). Furthermore, fetching lyrics for streams is not necessarily desirable (I use music streams only once, and they often contain more than one song).

I also documented this decision process in a comment above `Lyrics::fetchInBackground`, please let me know if that's not the right place. Also, please let me know what you think in general, and whether a different solution could perhaps be better.