### PR TITLE
fix: update obsolete macros in autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_PREREQ([2.71])
 
 AC_LANG([C++])
 AC_PROG_CXX
-AC_PROG_LIBTOOL
+LT_INIT
 
 AC_ARG_ENABLE(outputs, AS_HELP_STRING([--enable-outputs], [Enable outputs screen @<:@default=no@:>@]), [outputs=$enableval], [outputs=no])
 AC_ARG_ENABLE(visualizer, AS_HELP_STRING([--enable-visualizer], [Enable music visualizer screen @<:@default=no@:>@]), [visualizer=$enableval], [visualizer=no])

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
-AC_INIT([ncmpcpp], [0.10_dev])
+AC_INIT([ncmpcpp],[0.10_dev])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
 
 AC_CONFIG_MACRO_DIR([m4])
 
-AC_PREREQ(2.59)
+AC_PREREQ([2.71])
 
-AC_LANG_CPLUSPLUS
+AC_LANG([C++])
 AC_PROG_CXX
 AC_PROG_LIBTOOL
 


### PR DESCRIPTION
When trying to build the project, I encounter several errors at the very first step - about obsolete autoconf macros.