### PR TITLE
Add sync_lyrics_to_tags option

### DIFF
--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -250,7 +250,7 @@ LyricsFetcher::Result TagsLyricsFetcher::fetch([[maybe_unused]] const std::strin
 
 	TagLib::PropertyMap properties = f.file()->properties();
 
-	if (properties.contains("LYRICS"))
+    if (properties.contains("LYRICS"))
 	{
 		result.first = true;
 		result.second = properties["LYRICS"].toString("\n\n").to8Bit(true);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -594,6 +594,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 		      return --mode;
 	      });
 	p.add("external_editor", &external_editor, "nano", adjust_path);
+    p.add("sync_lyrics_to_tags", &sync_lyrics_to_tags, "no", yes_no);
 	p.add("use_console_editor", &use_console_editor, "yes", yes_no);
 	p.add("colors_enabled", &colors_enabled, "yes", yes_no);
 	p.add("empty_tag_color", &empty_tags_color, "cyan");

--- a/src/settings.h
+++ b/src/settings.h
@@ -77,6 +77,7 @@ struct Configuration
 	Format::AST<wchar_t> new_header_second_line;
 
 	std::string external_editor;
+	bool sync_lyrics_to_tags;
 	std::string system_encoding;
 	std::string execute_on_song_change;
 	std::string execute_on_player_state_change;


### PR DESCRIPTION
This solves #273, because it adds the ability to automatically sync lyrics after editing a file.
Issues:
- Only works when the editor is a console editor
- Only works on MP3 files (it uses the MPEG fileref)