### PR TITLE
Add native MPRIS D-Bus support for mpris/playerctl and waybar-mpris module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,10 +14,12 @@ LT_INIT
 AC_ARG_ENABLE(outputs, AS_HELP_STRING([--enable-outputs], [Enable outputs screen @<:@default=no@:>@]), [outputs=$enableval], [outputs=no])
 AC_ARG_ENABLE(visualizer, AS_HELP_STRING([--enable-visualizer], [Enable music visualizer screen @<:@default=no@:>@]), [visualizer=$enableval], [visualizer=no])
 AC_ARG_ENABLE(clock, AS_HELP_STRING([--enable-clock], [Enable clock screen @<:@default=no@:>@]), [clock=$enableval], [clock=no])
+AC_ARG_ENABLE(dbus_mpris, AS_HELP_STRING([--enable-dbus-mpris], [Enable MPRIS2 D-Bus interface (for playerctl) @<:@default=auto@:>@]), [dbus_mpris=$enableval], [dbus_mpris=auto])
 
 AC_ARG_WITH(fftw, AS_HELP_STRING([--with-fftw], [Enable fftw support (required for frequency spectrum vizualization) @<:@default=auto@:>@]), [fftw=$withval], [fftw=auto])
 AC_ARG_WITH(taglib, AS_HELP_STRING([--with-taglib], [Enable tag editor @<:@default=auto@:>@]), [taglib=$withval], [taglib=auto])
 AC_ARG_WITH(lto, AS_HELP_STRING([--with-lto], [Enable LTO (link time optimization) @<:@default=yes@:>@]), [lto=$withval], [lto=yes])
+
 
 if test "$outputs" = "yes"; then
 	AC_DEFINE([ENABLE_OUTPUTS], [1], [enables outputs screen])
@@ -257,6 +259,21 @@ PKG_CHECK_MODULES([libcurl], [libcurl], [
 ],
 	AC_MSG_ERROR([libcurl is required!])
 )
+
+# dbus-1 (optional, for MPRIS)
+if test "$dbus_mpris" != "no"; then
+	PKG_CHECK_MODULES([dbus1], [dbus-1], [
+		AC_SUBST(dbus1_CFLAGS)
+		AC_SUBST(dbus1_LIBS)
+		CPPFLAGS="$CPPFLAGS $dbus1_CFLAGS"
+		LIBS="$LIBS $dbus1_LIBS"
+		AC_DEFINE([ENABLE_DBUS_MPRIS], [1], [enable MPRIS2 D-Bus interface])
+	], [
+		if test "$dbus_mpris" = "yes"; then
+			AC_MSG_ERROR([dbus-1 is required when --enable-dbus-mpris is requested])
+		fi
+	])
+fi
 
 # taglib
 if test "$taglib" != "no" ; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,7 @@ ncmpcpp_SOURCES = \
 	macro_utilities.cpp \
 	mpdpp.cpp \
 	mutable_song.cpp \
+	mpris_dbus.cpp \
 	ncmpcpp.cpp \
 	settings.cpp \
 	song.cpp \
@@ -115,6 +116,7 @@ noinst_HEADERS = \
 	macro_utilities.h \
 	mpdpp.h \
 	mutable_song.h \
+	mpris_dbus.h \
 	regex_filter.h \
 	runnable_item.h \
 	settings.h \

--- a/src/mpris_dbus.cpp
+++ b/src/mpris_dbus.cpp
@@ -1,0 +1,929 @@
+/***************************************************************************
+ *   Copyright (C) 2026-Now rbrgmn <roman.bergman@tutanota.com>            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+
+#include "mpris_dbus.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "config.h"
+#include "mpdpp.h"
+#include "status.h"
+#include "statusbar.h"
+
+#ifdef ENABLE_DBUS_MPRIS
+#include <dbus/dbus.h>
+#endif
+
+namespace {
+
+#ifdef ENABLE_DBUS_MPRIS
+
+// Single exported MPRIS service/object for this process.
+constexpr const char *kService = "org.mpris.MediaPlayer2.ncmpcpp";
+constexpr const char *kPath = "/org/mpris/MediaPlayer2";
+constexpr const char *kMprisInterface = "org.mpris.MediaPlayer2";
+constexpr const char *kPlayerInterface = "org.mpris.MediaPlayer2.Player";
+constexpr const char *kPropertiesInterface = "org.freedesktop.DBus.Properties";
+constexpr const char *kIntrospectInterface =
+    "org.freedesktop.DBus.Introspectable";
+
+const char *kIntrospectionXml =
+    R"(<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg name="interface_name" type="s"/>
+   <arg name="changed_properties" type="a{sv}"/>
+   <arg name="invalidated_properties" type="as"/>
+  </signal>
+ </interface>
+ <interface name="org.mpris.MediaPlayer2">
+  <method name="Raise"/>
+  <method name="Quit"/>
+  <property name="CanQuit" type="b" access="read"/>
+  <property name="CanRaise" type="b" access="read"/>
+  <property name="CanSetFullscreen" type="b" access="read"/>
+  <property name="HasTrackList" type="b" access="read"/>
+  <property name="Identity" type="s" access="read"/>
+  <property name="DesktopEntry" type="s" access="read"/>
+  <property name="Fullscreen" type="b" access="read"/>
+  <property name="SupportedUriSchemes" type="as" access="read"/>
+  <property name="SupportedMimeTypes" type="as" access="read"/>
+ </interface>
+ <interface name="org.mpris.MediaPlayer2.Player">
+  <method name="Next"/>
+  <method name="Previous"/>
+  <method name="Pause"/>
+  <method name="PlayPause"/>
+  <method name="Stop"/>
+  <method name="Play"/>
+  <method name="Seek">
+   <arg name="Offset" type="x" direction="in"/>
+  </method>
+  <method name="SetPosition">
+   <arg name="TrackId" type="o" direction="in"/>
+   <arg name="Position" type="x" direction="in"/>
+  </method>
+  <method name="OpenUri">
+   <arg name="Uri" type="s" direction="in"/>
+  </method>
+  <signal name="Seeked">
+   <arg name="Position" type="x"/>
+  </signal>
+  <property name="PlaybackStatus" type="s" access="read"/>
+  <property name="LoopStatus" type="s" access="readwrite"/>
+  <property name="Rate" type="d" access="readwrite"/>
+  <property name="Shuffle" type="b" access="readwrite"/>
+  <property name="Metadata" type="a{sv}" access="read"/>
+  <property name="Volume" type="d" access="readwrite"/>
+  <property name="Position" type="x" access="read"/>
+  <property name="MinimumRate" type="d" access="read"/>
+  <property name="MaximumRate" type="d" access="read"/>
+  <property name="CanGoNext" type="b" access="read"/>
+  <property name="CanGoPrevious" type="b" access="read"/>
+  <property name="CanPlay" type="b" access="read"/>
+  <property name="CanPause" type="b" access="read"/>
+  <property name="CanSeek" type="b" access="read"/>
+  <property name="CanControl" type="b" access="read"/>
+ </interface>
+</node>
+)";
+
+DBusConnection *g_conn = nullptr;
+int g_fd = -1;
+
+struct Snapshot {
+  bool valid = false;
+  std::string playback;
+  std::string loop;
+  bool shuffle = false;
+  double volume = 0.0;
+  int song_id = -1;
+  int64_t position_us = 0;
+};
+
+// Last published state snapshot used to emit delta-only PropertiesChanged.
+Snapshot g_last_snapshot;
+
+const char *playbackState() {
+  // Map internal MPD state to MPRIS PlaybackStatus.
+  switch (Status::State::player()) {
+  case MPD::psPlay:
+    return "Playing";
+  case MPD::psPause:
+    return "Paused";
+  case MPD::psStop:
+  case MPD::psUnknown:
+    return "Stopped";
+  }
+  return "Stopped";
+}
+
+const char *loopStatus() {
+  if (Status::State::single() && Status::State::repeat())
+    return "Track";
+  if (Status::State::repeat())
+    return "Playlist";
+  return "None";
+}
+
+bool shuffleEnabled() { return Status::State::random(); }
+
+double volumeLevel() {
+  const int v = Status::State::volume();
+  return v >= 0 ? v / 100.0 : 0.0;
+}
+
+int64_t positionMicros() {
+  return static_cast<int64_t>(Status::State::elapsedTime()) * 1000000LL;
+}
+
+std::string currentTrackPath() {
+  int id = Status::State::currentSongID();
+  if (id < 0)
+    id = 0;
+  return std::string("/org/mpris/MediaPlayer2/track/") + std::to_string(id);
+}
+
+Snapshot currentSnapshot() {
+  Snapshot s;
+  s.valid = true;
+  s.playback = playbackState();
+  s.loop = loopStatus();
+  s.shuffle = shuffleEnabled();
+  s.volume = volumeLevel();
+  s.song_id = Status::State::currentSongID();
+  s.position_us = positionMicros();
+  return s;
+}
+
+DBusMessage *methodReturn(DBusMessage *msg) {
+  return dbus_message_new_method_return(msg);
+}
+
+DBusMessage *errorReply(DBusMessage *msg, const char *name, const char *text) {
+  return dbus_message_new_error(msg, name, text);
+}
+
+void appendVariantBool(DBusMessageIter *iter, bool value) {
+  dbus_bool_t db = value ? TRUE : FALSE;
+  DBusMessageIter v;
+  dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT,
+                                   DBUS_TYPE_BOOLEAN_AS_STRING, &v);
+  dbus_message_iter_append_basic(&v, DBUS_TYPE_BOOLEAN, &db);
+  dbus_message_iter_close_container(iter, &v);
+}
+
+void appendVariantString(DBusMessageIter *iter, const char *value) {
+  DBusMessageIter v;
+  dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT,
+                                   DBUS_TYPE_STRING_AS_STRING, &v);
+  dbus_message_iter_append_basic(&v, DBUS_TYPE_STRING, &value);
+  dbus_message_iter_close_container(iter, &v);
+}
+
+void appendVariantInt64(DBusMessageIter *iter, int64_t value) {
+  DBusMessageIter v;
+  dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT,
+                                   DBUS_TYPE_INT64_AS_STRING, &v);
+  dbus_message_iter_append_basic(&v, DBUS_TYPE_INT64, &value);
+  dbus_message_iter_close_container(iter, &v);
+}
+
+void appendVariantDouble(DBusMessageIter *iter, double value) {
+  DBusMessageIter v;
+  dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT,
+                                   DBUS_TYPE_DOUBLE_AS_STRING, &v);
+  dbus_message_iter_append_basic(&v, DBUS_TYPE_DOUBLE, &value);
+  dbus_message_iter_close_container(iter, &v);
+}
+
+void appendVariantStringArray(DBusMessageIter *iter,
+                              const std::vector<const char *> &values) {
+  DBusMessageIter v, arr;
+  dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, "as", &v);
+  dbus_message_iter_open_container(&v, DBUS_TYPE_ARRAY,
+                                   DBUS_TYPE_STRING_AS_STRING, &arr);
+  for (auto *value : values)
+    dbus_message_iter_append_basic(&arr, DBUS_TYPE_STRING, &value);
+  dbus_message_iter_close_container(&v, &arr);
+  dbus_message_iter_close_container(iter, &v);
+}
+
+void appendVariantMetadata(DBusMessageIter *iter) {
+  // Build metadata lazily from current MPD song to keep responses up to date.
+  DBusMessageIter v, dict;
+  dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, "a{sv}", &v);
+  dbus_message_iter_open_container(&v, DBUS_TYPE_ARRAY, "{sv}", &dict);
+
+  MPD::Song song;
+  try {
+    song = Mpd.GetCurrentSong();
+  } catch (MPD::Error &) {
+  }
+
+  const auto track_id = currentTrackPath();
+  const char *track_id_c = track_id.c_str();
+  {
+    DBusMessageIter entry, variant;
+    const char *key = "mpris:trackid";
+    dbus_message_iter_open_container(&dict, DBUS_TYPE_DICT_ENTRY, nullptr,
+                                     &entry);
+    dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
+    dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT,
+                                     DBUS_TYPE_OBJECT_PATH_AS_STRING, &variant);
+    dbus_message_iter_append_basic(&variant, DBUS_TYPE_OBJECT_PATH,
+                                   &track_id_c);
+    dbus_message_iter_close_container(&entry, &variant);
+    dbus_message_iter_close_container(&dict, &entry);
+  }
+
+  if (!song.empty()) {
+    auto append_string_prop = [&dict](const char *name,
+                                      const std::string &value) {
+      if (value.empty())
+        return;
+      DBusMessageIter entry, variant;
+      const char *key = name;
+      const char *str = value.c_str();
+      dbus_message_iter_open_container(&dict, DBUS_TYPE_DICT_ENTRY, nullptr,
+                                       &entry);
+      dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
+      dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT,
+                                       DBUS_TYPE_STRING_AS_STRING, &variant);
+      dbus_message_iter_append_basic(&variant, DBUS_TYPE_STRING, &str);
+      dbus_message_iter_close_container(&entry, &variant);
+      dbus_message_iter_close_container(&dict, &entry);
+    };
+
+    auto append_string_array_prop =
+        [&dict](const char *name, const std::vector<std::string> &values) {
+          if (values.empty())
+            return;
+          DBusMessageIter entry, variant, arr;
+          const char *key = name;
+          dbus_message_iter_open_container(&dict, DBUS_TYPE_DICT_ENTRY, nullptr,
+                                           &entry);
+          dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
+          dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT, "as",
+                                           &variant);
+          dbus_message_iter_open_container(&variant, DBUS_TYPE_ARRAY,
+                                           DBUS_TYPE_STRING_AS_STRING, &arr);
+          for (const auto &value : values) {
+            const char *str = value.c_str();
+            dbus_message_iter_append_basic(&arr, DBUS_TYPE_STRING, &str);
+          }
+          dbus_message_iter_close_container(&variant, &arr);
+          dbus_message_iter_close_container(&entry, &variant);
+          dbus_message_iter_close_container(&dict, &entry);
+        };
+
+    auto append_int64_prop = [&dict](const char *name, int64_t value) {
+      DBusMessageIter entry, variant;
+      const char *key = name;
+      dbus_message_iter_open_container(&dict, DBUS_TYPE_DICT_ENTRY, nullptr,
+                                       &entry);
+      dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
+      dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT,
+                                       DBUS_TYPE_INT64_AS_STRING, &variant);
+      dbus_message_iter_append_basic(&variant, DBUS_TYPE_INT64, &value);
+      dbus_message_iter_close_container(&entry, &variant);
+      dbus_message_iter_close_container(&dict, &entry);
+    };
+
+    const auto title = song.getTitle();
+    const auto name = song.getName();
+    const auto artist = song.getArtist();
+    const auto album = song.getAlbum();
+    const auto uri = song.getURI();
+    const int64_t length_us =
+        static_cast<int64_t>(song.getDuration()) * 1000000LL;
+
+    append_string_prop("xesam:title", !title.empty() ? title : name);
+    if (!artist.empty())
+      append_string_array_prop("xesam:artist", {artist});
+    append_string_prop("xesam:album", album);
+    append_string_prop("xesam:url", uri);
+    append_int64_prop("mpris:length", length_us);
+  }
+
+  dbus_message_iter_close_container(&v, &dict);
+  dbus_message_iter_close_container(iter, &v);
+}
+
+void appendPropBool(DBusMessageIter *dict, const char *name, bool value) {
+  DBusMessageIter entry;
+  dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+  dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &name);
+  appendVariantBool(&entry, value);
+  dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendPropString(DBusMessageIter *dict, const char *name,
+                      const char *value) {
+  DBusMessageIter entry;
+  dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+  dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &name);
+  appendVariantString(&entry, value);
+  dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendPropDouble(DBusMessageIter *dict, const char *name, double value) {
+  DBusMessageIter entry;
+  dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+  dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &name);
+  appendVariantDouble(&entry, value);
+  dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendPropInt64(DBusMessageIter *dict, const char *name, int64_t value) {
+  DBusMessageIter entry;
+  dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+  dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &name);
+  appendVariantInt64(&entry, value);
+  dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendPropStringArray(DBusMessageIter *dict, const char *name,
+                           const std::vector<const char *> &values) {
+  DBusMessageIter entry;
+  dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+  dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &name);
+  appendVariantStringArray(&entry, values);
+  dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendPropMetadata(DBusMessageIter *dict, const char *name) {
+  DBusMessageIter entry;
+  dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY, nullptr, &entry);
+  dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &name);
+  appendVariantMetadata(&entry);
+  dbus_message_iter_close_container(dict, &entry);
+}
+
+void appendPlayerProp(DBusMessageIter *iter, const char *prop) {
+  // Centralized property encoder used by Properties.Get.
+  if (!std::strcmp(prop, "PlaybackStatus"))
+    appendVariantString(iter, playbackState());
+  else if (!std::strcmp(prop, "Metadata"))
+    appendVariantMetadata(iter);
+  else if (!std::strcmp(prop, "Position"))
+    appendVariantInt64(iter, positionMicros());
+  else if (!std::strcmp(prop, "Rate") || !std::strcmp(prop, "MinimumRate") ||
+           !std::strcmp(prop, "MaximumRate"))
+    appendVariantDouble(iter, 1.0);
+  else if (!std::strcmp(prop, "Volume"))
+    appendVariantDouble(iter, volumeLevel());
+  else if (!std::strcmp(prop, "LoopStatus"))
+    appendVariantString(iter, loopStatus());
+  else if (!std::strcmp(prop, "Shuffle"))
+    appendVariantBool(iter, shuffleEnabled());
+  else if (!std::strcmp(prop, "CanGoNext") ||
+           !std::strcmp(prop, "CanGoPrevious") ||
+           !std::strcmp(prop, "CanPlay") || !std::strcmp(prop, "CanPause") ||
+           !std::strcmp(prop, "CanControl") || !std::strcmp(prop, "CanSeek"))
+    appendVariantBool(iter, true);
+  else
+    throw std::runtime_error("unknown player property");
+}
+
+void appendMprisProp(DBusMessageIter *iter, const char *prop) {
+  if (!std::strcmp(prop, "CanQuit") || !std::strcmp(prop, "CanRaise") ||
+      !std::strcmp(prop, "HasTrackList") ||
+      !std::strcmp(prop, "CanSetFullscreen") ||
+      !std::strcmp(prop, "Fullscreen"))
+    appendVariantBool(iter, false);
+  else if (!std::strcmp(prop, "Identity"))
+    appendVariantString(iter, "ncmpcpp");
+  else if (!std::strcmp(prop, "DesktopEntry"))
+    appendVariantString(iter, "ncmpcpp");
+  else if (!std::strcmp(prop, "SupportedUriSchemes"))
+    appendVariantStringArray(iter, {"file", "http", "https"});
+  else if (!std::strcmp(prop, "SupportedMimeTypes"))
+    appendVariantStringArray(iter, {});
+  else
+    throw std::runtime_error("unknown mpris property");
+}
+
+DBusMessage *handleGet(DBusMessage *msg) {
+  // org.freedesktop.DBus.Properties.Get
+  DBusError err;
+  dbus_error_init(&err);
+  const char *iface = nullptr;
+  const char *prop = nullptr;
+  if (!dbus_message_get_args(msg, &err, DBUS_TYPE_STRING, &iface,
+                             DBUS_TYPE_STRING, &prop, DBUS_TYPE_INVALID)) {
+    auto out = errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                          err.message ? err.message : "invalid args");
+    dbus_error_free(&err);
+    return out;
+  }
+
+  auto out = methodReturn(msg);
+  DBusMessageIter iter;
+  dbus_message_iter_init_append(out, &iter);
+  try {
+    if (!std::strcmp(iface, kPlayerInterface))
+      appendPlayerProp(&iter, prop);
+    else if (!std::strcmp(iface, kMprisInterface))
+      appendMprisProp(&iter, prop);
+    else {
+      dbus_message_unref(out);
+      return errorReply(msg, DBUS_ERROR_UNKNOWN_INTERFACE, "unknown interface");
+    }
+  } catch (std::runtime_error &) {
+    dbus_message_unref(out);
+    return errorReply(msg, DBUS_ERROR_UNKNOWN_PROPERTY, "unknown property");
+  }
+  return out;
+}
+
+DBusMessage *handleGetAll(DBusMessage *msg) {
+  // org.freedesktop.DBus.Properties.GetAll
+  DBusError err;
+  dbus_error_init(&err);
+  const char *iface = nullptr;
+  if (!dbus_message_get_args(msg, &err, DBUS_TYPE_STRING, &iface,
+                             DBUS_TYPE_INVALID)) {
+    auto out = errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                          err.message ? err.message : "invalid args");
+    dbus_error_free(&err);
+    return out;
+  }
+
+  auto out = methodReturn(msg);
+  DBusMessageIter iter, dict;
+  dbus_message_iter_init_append(out, &iter);
+  dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "{sv}", &dict);
+
+  if (!std::strcmp(iface, kPlayerInterface)) {
+    appendPropString(&dict, "PlaybackStatus", playbackState());
+    appendPropMetadata(&dict, "Metadata");
+    appendPropInt64(&dict, "Position", positionMicros());
+    appendPropDouble(&dict, "Rate", 1.0);
+    appendPropDouble(&dict, "MinimumRate", 1.0);
+    appendPropDouble(&dict, "MaximumRate", 1.0);
+    appendPropDouble(&dict, "Volume", volumeLevel());
+    appendPropString(&dict, "LoopStatus", loopStatus());
+    appendPropBool(&dict, "Shuffle", shuffleEnabled());
+    appendPropBool(&dict, "CanGoNext", true);
+    appendPropBool(&dict, "CanGoPrevious", true);
+    appendPropBool(&dict, "CanPlay", true);
+    appendPropBool(&dict, "CanPause", true);
+    appendPropBool(&dict, "CanSeek", true);
+    appendPropBool(&dict, "CanControl", true);
+  } else if (!std::strcmp(iface, kMprisInterface)) {
+    appendPropBool(&dict, "CanQuit", false);
+    appendPropBool(&dict, "CanRaise", false);
+    appendPropBool(&dict, "CanSetFullscreen", false);
+    appendPropBool(&dict, "HasTrackList", false);
+    appendPropBool(&dict, "Fullscreen", false);
+    appendPropString(&dict, "Identity", "ncmpcpp");
+    appendPropString(&dict, "DesktopEntry", "ncmpcpp");
+    appendPropStringArray(&dict, "SupportedUriSchemes",
+                          {"file", "http", "https"});
+    appendPropStringArray(&dict, "SupportedMimeTypes", {});
+  } else {
+    dbus_message_unref(out);
+    return errorReply(msg, DBUS_ERROR_UNKNOWN_INTERFACE, "unknown interface");
+  }
+
+  dbus_message_iter_close_container(&iter, &dict);
+  return out;
+}
+
+void emitSeeked(int64_t position_us) {
+  // MPRIS Player.Seeked signal after successful seek operations.
+  auto *signal = dbus_message_new_signal(kPath, kPlayerInterface, "Seeked");
+  if (signal == nullptr)
+    return;
+  dbus_message_append_args(signal, DBUS_TYPE_INT64, &position_us,
+                           DBUS_TYPE_INVALID);
+  dbus_connection_send(g_conn, signal, nullptr);
+  dbus_message_unref(signal);
+}
+
+void emitPlayerChanged(const Snapshot &old_s, const Snapshot &new_s) {
+  // Emit only changed fields to minimize bus traffic and avoid noisy redraws.
+  if (g_conn == nullptr)
+    return;
+
+  const bool playback_changed =
+      !old_s.valid || old_s.playback != new_s.playback;
+  const bool loop_changed = !old_s.valid || old_s.loop != new_s.loop;
+  const bool shuffle_changed = !old_s.valid || old_s.shuffle != new_s.shuffle;
+  const bool volume_changed =
+      !old_s.valid || std::fabs(old_s.volume - new_s.volume) > 1e-9;
+  const bool song_changed = !old_s.valid || old_s.song_id != new_s.song_id;
+  if (!(playback_changed || loop_changed || shuffle_changed || volume_changed ||
+        song_changed))
+    return;
+
+  auto *signal =
+      dbus_message_new_signal(kPath, kPropertiesInterface, "PropertiesChanged");
+  if (signal == nullptr)
+    return;
+
+  DBusMessageIter iter, changed, invalidated;
+  dbus_message_iter_init_append(signal, &iter);
+  const char *iface = kPlayerInterface;
+  dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &iface);
+  dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "{sv}", &changed);
+
+  if (playback_changed)
+    appendPropString(&changed, "PlaybackStatus", playbackState());
+  if (loop_changed)
+    appendPropString(&changed, "LoopStatus", loopStatus());
+  if (shuffle_changed)
+    appendPropBool(&changed, "Shuffle", shuffleEnabled());
+  if (volume_changed)
+    appendPropDouble(&changed, "Volume", volumeLevel());
+  if (song_changed) {
+    appendPropMetadata(&changed, "Metadata");
+    appendPropInt64(&changed, "Position", positionMicros());
+  }
+
+  dbus_message_iter_close_container(&iter, &changed);
+  dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY,
+                                   DBUS_TYPE_STRING_AS_STRING, &invalidated);
+  dbus_message_iter_close_container(&iter, &invalidated);
+
+  dbus_connection_send(g_conn, signal, nullptr);
+  dbus_message_unref(signal);
+}
+
+bool parseSetValue(DBusMessage *msg, const char **iface, const char **prop,
+                   DBusMessageIter *value) {
+  // Parse (interface_name, property_name, variant value) from Set call.
+  DBusMessageIter it;
+  if (!dbus_message_iter_init(msg, &it) ||
+      dbus_message_iter_get_arg_type(&it) != DBUS_TYPE_STRING)
+    return false;
+  dbus_message_iter_get_basic(&it, iface);
+  if (!dbus_message_iter_next(&it) ||
+      dbus_message_iter_get_arg_type(&it) != DBUS_TYPE_STRING)
+    return false;
+  dbus_message_iter_get_basic(&it, prop);
+  if (!dbus_message_iter_next(&it) ||
+      dbus_message_iter_get_arg_type(&it) != DBUS_TYPE_VARIANT)
+    return false;
+  dbus_message_iter_recurse(&it, value);
+  return true;
+}
+
+DBusMessage *handleSet(DBusMessage *msg) {
+  // org.freedesktop.DBus.Properties.Set for writable Player properties.
+  const char *iface = nullptr;
+  const char *prop = nullptr;
+  DBusMessageIter value;
+  if (!parseSetValue(msg, &iface, &prop, &value))
+    return errorReply(msg, DBUS_ERROR_INVALID_ARGS, "invalid args");
+
+  if (std::strcmp(iface, kPlayerInterface) != 0)
+    return errorReply(msg, DBUS_ERROR_UNKNOWN_INTERFACE, "unknown interface");
+
+  try {
+    if (!std::strcmp(prop, "Volume")) {
+      if (dbus_message_iter_get_arg_type(&value) != DBUS_TYPE_DOUBLE)
+        return errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                          "Volume expects double");
+      double v = 0.0;
+      dbus_message_iter_get_basic(&value, &v);
+      if (v < 0.0)
+        v = 0.0;
+      if (v > 1.0)
+        v = 1.0;
+      Mpd.SetVolume(static_cast<unsigned>(std::lround(v * 100.0)));
+    } else if (!std::strcmp(prop, "Shuffle")) {
+      if (dbus_message_iter_get_arg_type(&value) != DBUS_TYPE_BOOLEAN)
+        return errorReply(msg, DBUS_ERROR_INVALID_ARGS, "Shuffle expects bool");
+      dbus_bool_t b = FALSE;
+      dbus_message_iter_get_basic(&value, &b);
+      Mpd.SetRandom(b == TRUE);
+    } else if (!std::strcmp(prop, "LoopStatus")) {
+      if (dbus_message_iter_get_arg_type(&value) != DBUS_TYPE_STRING)
+        return errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                          "LoopStatus expects string");
+      const char *ls = nullptr;
+      dbus_message_iter_get_basic(&value, &ls);
+      if (!std::strcmp(ls, "None")) {
+        Mpd.SetRepeat(false);
+        Mpd.SetSingle(false);
+      } else if (!std::strcmp(ls, "Playlist")) {
+        Mpd.SetRepeat(true);
+        Mpd.SetSingle(false);
+      } else if (!std::strcmp(ls, "Track")) {
+        Mpd.SetRepeat(true);
+        Mpd.SetSingle(true);
+      } else
+        return errorReply(msg, DBUS_ERROR_INVALID_ARGS, "invalid LoopStatus");
+    } else if (!std::strcmp(prop, "Rate")) {
+      if (dbus_message_iter_get_arg_type(&value) != DBUS_TYPE_DOUBLE)
+        return errorReply(msg, DBUS_ERROR_INVALID_ARGS, "Rate expects double");
+      double rate = 0.0;
+      dbus_message_iter_get_basic(&value, &rate);
+      if (std::fabs(rate - 1.0) > 1e-9)
+        return errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                          "only Rate=1.0 is supported");
+    } else
+      return errorReply(msg, DBUS_ERROR_PROPERTY_READ_ONLY,
+                        "property is read-only");
+  } catch (MPD::ClientError &e) {
+    Status::handleClientError(e);
+    return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+  } catch (MPD::ServerError &e) {
+    Status::handleServerError(e);
+    return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+  }
+
+  return methodReturn(msg);
+}
+
+void callMpdAndMaybeNotify(void (*fn)(), const char *ok_msg) {
+  try {
+    fn();
+    Statusbar::print(1, ok_msg);
+  } catch (MPD::ClientError &e) {
+    Status::handleClientError(e);
+  } catch (MPD::ServerError &e) {
+    Status::handleServerError(e);
+  }
+}
+
+int64_t floorDivMicrosToSeconds(int64_t us) {
+  // MPRIS uses microseconds while MPD seek API expects seconds.
+  // Floor division keeps negative offsets well-defined.
+  int64_t s = us / 1000000LL;
+  if (us < 0 && (us % 1000000LL) != 0)
+    --s;
+  return s;
+}
+
+DBusMessage *handlePlayerMethods(DBusMessage *msg) {
+  // Map Player methods to MPD operations.
+  if (dbus_message_is_method_call(msg, kPlayerInterface, "Next"))
+    callMpdAndMaybeNotify(+[]() { Mpd.Next(); }, "MPRIS: next");
+  else if (dbus_message_is_method_call(msg, kPlayerInterface, "Previous"))
+    callMpdAndMaybeNotify(+[]() { Mpd.Prev(); }, "MPRIS: previous");
+  else if (dbus_message_is_method_call(msg, kPlayerInterface, "PlayPause"))
+    callMpdAndMaybeNotify(+[]() { Mpd.Toggle(); }, "MPRIS: play/pause");
+  else if (dbus_message_is_method_call(msg, kPlayerInterface, "Play"))
+    callMpdAndMaybeNotify(+[]() { Mpd.Play(); }, "MPRIS: play");
+  else if (dbus_message_is_method_call(msg, kPlayerInterface, "Pause"))
+    callMpdAndMaybeNotify(+[]() { Mpd.Pause(1); }, "MPRIS: pause");
+  else if (dbus_message_is_method_call(msg, kPlayerInterface, "Stop"))
+    callMpdAndMaybeNotify(+[]() { Mpd.Stop(); }, "MPRIS: stop");
+  else if (dbus_message_is_method_call(msg, kPlayerInterface, "Seek")) {
+    DBusError err;
+    dbus_error_init(&err);
+    int64_t offset_us = 0;
+    if (!dbus_message_get_args(msg, &err, DBUS_TYPE_INT64, &offset_us,
+                               DBUS_TYPE_INVALID)) {
+      auto out = errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                            err.message ? err.message : "invalid args");
+      dbus_error_free(&err);
+      return out;
+    }
+    try {
+      const int pos = Status::State::currentSongPosition();
+      if (pos >= 0) {
+        int64_t target = static_cast<int64_t>(Status::State::elapsedTime()) +
+                         floorDivMicrosToSeconds(offset_us);
+        if (target < 0)
+          target = 0;
+        const int64_t total = Status::State::totalTime();
+        if (total > 0 && target > total)
+          target = total;
+        Mpd.Seek(static_cast<unsigned int>(pos),
+                 static_cast<unsigned int>(target));
+        emitSeeked(target * 1000000LL);
+      }
+    } catch (MPD::ClientError &e) {
+      Status::handleClientError(e);
+      return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+    } catch (MPD::ServerError &e) {
+      Status::handleServerError(e);
+      return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+    }
+  } else if (dbus_message_is_method_call(msg, kPlayerInterface,
+                                         "SetPosition")) {
+    DBusError err;
+    dbus_error_init(&err);
+    const char *track = nullptr;
+    int64_t position_us = 0;
+    if (!dbus_message_get_args(msg, &err, DBUS_TYPE_OBJECT_PATH, &track,
+                               DBUS_TYPE_INT64, &position_us,
+                               DBUS_TYPE_INVALID)) {
+      auto out = errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                            err.message ? err.message : "invalid args");
+      dbus_error_free(&err);
+      return out;
+    }
+
+    const auto curr = currentTrackPath();
+    if (curr == track) {
+      try {
+        const int pos = Status::State::currentSongPosition();
+        if (pos >= 0) {
+          int64_t target = floorDivMicrosToSeconds(position_us);
+          if (target < 0)
+            target = 0;
+          const int64_t total = Status::State::totalTime();
+          if (total > 0 && target > total)
+            target = total;
+          Mpd.Seek(static_cast<unsigned int>(pos),
+                   static_cast<unsigned int>(target));
+          emitSeeked(target * 1000000LL);
+        }
+      } catch (MPD::ClientError &e) {
+        Status::handleClientError(e);
+        return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+      } catch (MPD::ServerError &e) {
+        Status::handleServerError(e);
+        return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+      }
+    }
+  } else if (dbus_message_is_method_call(msg, kPlayerInterface, "OpenUri")) {
+    DBusError err;
+    dbus_error_init(&err);
+    const char *uri = nullptr;
+    if (!dbus_message_get_args(msg, &err, DBUS_TYPE_STRING, &uri,
+                               DBUS_TYPE_INVALID)) {
+      auto out = errorReply(msg, DBUS_ERROR_INVALID_ARGS,
+                            err.message ? err.message : "invalid args");
+      dbus_error_free(&err);
+      return out;
+    }
+    try {
+      const int id = Mpd.AddSong(uri);
+      if (id >= 0)
+        Mpd.PlayID(id);
+    } catch (MPD::ClientError &e) {
+      Status::handleClientError(e);
+      return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+    } catch (MPD::ServerError &e) {
+      Status::handleServerError(e);
+      return errorReply(msg, DBUS_ERROR_FAILED, e.what());
+    }
+  } else
+    return nullptr;
+
+  return methodReturn(msg);
+}
+
+DBusHandlerResult handleMessage(DBusConnection *, DBusMessage *msg, void *) {
+  // Main dispatcher for introspection, Properties API and Player methods.
+  if (dbus_message_is_method_call(msg, kIntrospectInterface, "Introspect")) {
+    auto out = methodReturn(msg);
+    DBusMessageIter iter;
+    dbus_message_iter_init_append(out, &iter);
+    const char *xml = kIntrospectionXml;
+    dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &xml);
+    dbus_connection_send(g_conn, out, nullptr);
+    dbus_message_unref(out);
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  if (dbus_message_is_method_call(msg, kPropertiesInterface, "Get")) {
+    auto out = handleGet(msg);
+    dbus_connection_send(g_conn, out, nullptr);
+    dbus_message_unref(out);
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+  if (dbus_message_is_method_call(msg, kPropertiesInterface, "GetAll")) {
+    auto out = handleGetAll(msg);
+    dbus_connection_send(g_conn, out, nullptr);
+    dbus_message_unref(out);
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+  if (dbus_message_is_method_call(msg, kPropertiesInterface, "Set")) {
+    auto out = handleSet(msg);
+    dbus_connection_send(g_conn, out, nullptr);
+    dbus_message_unref(out);
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  if (dbus_message_is_method_call(msg, kMprisInterface, "Raise") ||
+      dbus_message_is_method_call(msg, kMprisInterface, "Quit")) {
+    auto out = methodReturn(msg);
+    dbus_connection_send(g_conn, out, nullptr);
+    dbus_message_unref(out);
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  auto out = handlePlayerMethods(msg);
+  if (out != nullptr) {
+    dbus_connection_send(g_conn, out, nullptr);
+    dbus_message_unref(out);
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+}
+
+DBusObjectPathVTable kVTable = {nullptr, handleMessage, nullptr,
+                                nullptr, nullptr,       nullptr};
+
+#endif // ENABLE_DBUS_MPRIS
+
+} // namespace
+
+void MPRIS::initialize() {
+#ifdef ENABLE_DBUS_MPRIS
+  // Connect to session bus, own name and register object path.
+  DBusError err;
+  dbus_error_init(&err);
+  g_conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
+  if (g_conn == nullptr) {
+    dbus_error_free(&err);
+    return;
+  }
+  dbus_connection_set_exit_on_disconnect(g_conn, false);
+  const int ret = dbus_bus_request_name(g_conn, kService,
+                                        DBUS_NAME_FLAG_DO_NOT_QUEUE, &err);
+  if (dbus_error_is_set(&err) || ret != DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER) {
+    dbus_error_free(&err);
+    dbus_connection_unref(g_conn);
+    g_conn = nullptr;
+    return;
+  }
+  if (!dbus_connection_register_object_path(g_conn, kPath, &kVTable, nullptr)) {
+    dbus_connection_unref(g_conn);
+    g_conn = nullptr;
+    return;
+  }
+  if (!dbus_connection_get_unix_fd(g_conn, &g_fd))
+    g_fd = -1;
+  g_last_snapshot = Snapshot();
+#endif // ENABLE_DBUS_MPRIS
+}
+
+void MPRIS::shutdown() {
+#ifdef ENABLE_DBUS_MPRIS
+  if (g_conn != nullptr) {
+    dbus_connection_unregister_object_path(g_conn, kPath);
+    dbus_bus_release_name(g_conn, kService, nullptr);
+    dbus_connection_unref(g_conn);
+    g_conn = nullptr;
+    g_fd = -1;
+    g_last_snapshot = Snapshot();
+  }
+#endif // ENABLE_DBUS_MPRIS
+}
+
+void MPRIS::process() {
+#ifdef ENABLE_DBUS_MPRIS
+  if (g_conn == nullptr)
+    return;
+  // Pump incoming D-Bus messages, then publish state deltas as signals.
+  dbus_connection_read_write(g_conn, 0);
+  while (dbus_connection_get_dispatch_status(g_conn) ==
+         DBUS_DISPATCH_DATA_REMAINS)
+    dbus_connection_dispatch(g_conn);
+
+  const auto snap = currentSnapshot();
+  emitPlayerChanged(g_last_snapshot, snap);
+  g_last_snapshot = snap;
+#endif // ENABLE_DBUS_MPRIS
+}
+
+void MPRIS::registerFDCallback(NC::Window &w) {
+#ifdef ENABLE_DBUS_MPRIS
+  if (g_conn == nullptr || g_fd < 0)
+    return;
+  w.addFDCallback(g_fd, &MPRIS::process);
+#else
+  (void)w;
+#endif // ENABLE_DBUS_MPRIS
+}

--- a/src/mpris_dbus.h
+++ b/src/mpris_dbus.h
@@ -1,0 +1,26 @@
+/***************************************************************************
+ *   Copyright (C) 2026-Now  rbrgmn <roman.bergman@tutanota.com>           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+
+#ifndef NCMPCPP_MPRIS_DBUS_H
+#define NCMPCPP_MPRIS_DBUS_H
+
+namespace NC {
+struct Window;
+}
+
+namespace MPRIS {
+
+void initialize();
+void shutdown();
+void registerFDCallback(NC::Window &w);
+void process();
+
+} // namespace MPRIS
+
+#endif // NCMPCPP_MPRIS_DBUS_H

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -25,26 +25,27 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/locale.hpp>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 
 #include "mpdpp.h"
 
 #include "actions.h"
 #include "bindings.h"
-#include "screens/browser.h"
 #include "charset.h"
 #include "configuration.h"
 #include "global.h"
 #include "helpers.h"
+#include "mpris_dbus.h"
+#include "screens/browser.h"
 #include "screens/lyrics.h"
 #include "screens/outputs.h"
 #include "screens/playlist.h"
+#include "screens/visualizer.h"
 #include "settings.h"
 #include "status.h"
 #include "statusbar.h"
-#include "screens/visualizer.h"
 #include "title.h"
 #include "utility/conversion.h"
 
@@ -57,201 +58,189 @@ std::streambuf *cerr_buffer;
 std::streambuf *clog_buffer;
 
 volatile bool run_resize_screen = false;
-	
-void sighandler(int sig)
-{
-	if (sig == SIGWINCH)
-		run_resize_screen = true;
+
+void sighandler(int sig) {
+  if (sig == SIGWINCH)
+    run_resize_screen = true;
 #if defined(__sun) && defined(__SVR4)
-	// in solaris it is needed to reinstall the handler each time it's executed
-	signal(sig, sighandler);
+  // in solaris it is needed to reinstall the handler each time it's executed
+  signal(sig, sighandler);
 #endif // __sun && __SVR4
 }
 
-void do_at_exit()
-{
-	// restore old cerr & clog buffers
-	std::cerr.rdbuf(cerr_buffer);
-	std::clog.rdbuf(clog_buffer);
-	errorlog.close();
-	Mpd.Disconnect();
-	NC::destroyScreen();
-	windowTitle("");
+void do_at_exit() {
+  MPRIS::shutdown();
+
+  // restore old cerr & clog buffers
+  std::cerr.rdbuf(cerr_buffer);
+  std::clog.rdbuf(clog_buffer);
+  errorlog.close();
+  Mpd.Disconnect();
+  NC::destroyScreen();
+  windowTitle("");
 }
 
-}
+} // namespace
 
-int main(int argc, char **argv)
-{
-	using Global::myScreen;
-	
-	using Global::wHeader;
-	using Global::wFooter;
-	
-	using Global::VolumeState;
-	using Global::Timer;
-	
-	std::setlocale(LC_ALL, "");
-	std::locale::global(Charset::internalLocale());
+int main(int argc, char **argv) {
+  using Global::myScreen;
 
-	// clog might be overriden in configure, so preserve the original buffer.
-	clog_buffer = std::clog.rdbuf();
+  using Global::wFooter;
+  using Global::wHeader;
 
-	if (!configure(argc, argv))
-		return 0;
-	
-	// always execute these commands, even if ncmpcpp use exit function
-	atexit(do_at_exit);
-	
-	// redirect std::cerr output to the error.log file
-	errorlog.open((Config.ncmpcpp_directory + "error.log").c_str(), std::ios::app);
-	cerr_buffer = std::cerr.rdbuf();
-	std::cerr.rdbuf(errorlog.rdbuf());
-	
-	signal(SIGPIPE, SIG_IGN);
-	signal(SIGWINCH, sighandler);
+  using Global::Timer;
+  using Global::VolumeState;
 
-	Mpd.setNoidleCallback(Status::update);
+  std::setlocale(LC_ALL, "");
+  std::locale::global(Charset::internalLocale());
 
-	NC::initScreen(Config.colors_enabled, Config.mouse_support);
-	
-	Actions::OriginalStatusbarVisibility = Config.statusbar_visibility;
+  // clog might be overriden in configure, so preserve the original buffer.
+  clog_buffer = std::clog.rdbuf();
 
-	if (Config.design == Design::Alternative)
-		Config.statusbar_visibility = 0;
-	
-	Actions::setWindowsDimensions();
-	Actions::initializeScreens();
-	
-	wHeader = new NC::Window(0, 0, COLS, Actions::HeaderHeight, "", Config.header_color, NC::Border());
-	if (Config.header_visibility || Config.design == Design::Alternative)
-		wHeader->display();
-	
-	wFooter = new NC::Window(0, Actions::FooterStartY, COLS, Actions::FooterHeight, "", Config.statusbar_color, NC::Border());
-	wFooter->setPromptHook(Statusbar::Helpers::mainHook);
-	
-	// initialize global timer
-	Timer = boost::posix_time::microsec_clock::local_time();
+  if (!configure(argc, argv))
+    return 0;
 
-	// initialize global random number generator
-	Global::RNG.seed(std::random_device()());
-	
-	// initialize playlist
-	myPlaylist->switchTo();
+  // always execute these commands, even if ncmpcpp use exit function
+  atexit(do_at_exit);
 
-	// go to startup screen
-	if (Config.startup_screen_type != myScreen->type())
-	{
-		auto startup_screen = toScreen(Config.startup_screen_type);
-		assert(startup_screen != nullptr);
-		startup_screen->switchTo();
-	}
+  // redirect std::cerr output to the error.log file
+  errorlog.open((Config.ncmpcpp_directory + "error.log").c_str(),
+                std::ios::app);
+  cerr_buffer = std::cerr.rdbuf();
+  std::cerr.rdbuf(errorlog.rdbuf());
 
-	// lock current screen and go to the slave one if applicable
-	if (Config.startup_slave_screen_type)
-	{
-		auto slave_screen_type = *Config.startup_slave_screen_type;
-		bool screen_locked = myScreen->lock();
-		if (screen_locked && slave_screen_type != myScreen->type())
-		{
-			auto slave_screen = toScreen(slave_screen_type);
-			assert(slave_screen != nullptr);
-			slave_screen->switchTo();
-			if (!Config.startup_slave_screen_focus)
-				Actions::get(Actions::Type::MasterScreen).execute();
-		}
-	}
+  signal(SIGPIPE, SIG_IGN);
+  signal(SIGWINCH, sighandler);
 
-	// local variables
-	bool key_pressed = false;
-	auto input = NC::Key::None;
-	auto connect_attempt = boost::posix_time::from_time_t(0);
-	auto update_environment = static_cast<Actions::UpdateEnvironment &>(
-		Actions::get(Actions::Type::UpdateEnvironment));
-	
-	while (!Actions::ExitMainLoop)
-	{
-		try
-		{
-			if (!Mpd.Connected() && Timer - connect_attempt > boost::posix_time::seconds(1))
-			{
-				connect_attempt = Timer;
-				// reset local status info
-				Status::clear();
-				// clear mpd callback
-				wFooter->clearFDCallbacksList();
-				try
-				{
-					Mpd.Connect();
-					if (Mpd.Version() < 16)
-					{
-							Mpd.Disconnect();
-							throw MPD::ClientError(MPD_ERROR_STATE, "MPD < 0.16.0 is not supported", false);
-					}
-				}
-				catch (MPD::ClientError &e)
-				{
-					Status::handleClientError(e);
-				}
-			}
+  Mpd.setNoidleCallback(Status::update);
 
-			if (run_resize_screen)
-			{
-				Actions::resizeScreen(true);
-				run_resize_screen = false;
-			}
+  NC::initScreen(Config.colors_enabled, Config.mouse_support);
 
-			update_environment.run(!key_pressed, key_pressed, false);
+  Actions::OriginalStatusbarVisibility = Config.statusbar_visibility;
 
-			input = readKey(*wFooter);
-			key_pressed = input != NC::Key::None;
-			if (!key_pressed)
-				continue;
+  if (Config.design == Design::Alternative)
+    Config.statusbar_visibility = 0;
 
-			// The reason we want to update timer here is that if the timer is updated
-			// in Status::trace, then Key::read usually blocks for 500ms and if key is
-			// pressed 400ms after Key::read was called, we end up with Timer that is
-			// ~400ms inaccurate. On the other hand, if keys are being pressed, we don't
-			// want to update timer in both Status::trace and here. Therefore we update
-			// timer in Status::trace only if there was no recent input.
-			Timer = boost::posix_time::microsec_clock::local_time();
+  Actions::setWindowsDimensions();
+  Actions::initializeScreens();
 
-			try
-			{
-				auto k = Bindings.get(input);
-				[[maybe_unused]] bool executed = std::any_of(
-					k.first,
-					k.second,
-					std::bind(&Binding::execute, ph::_1));
-			}
-			catch (ConversionError &e)
-			{
-				Statusbar::printf("Invalid value: %1%", e.value());
-			}
-			catch (OutOfBounds &e)
-			{
-				Statusbar::printf("Error: %1%", e.errorMessage());
-			}
-			catch (NC::PromptAborted &)
-			{
-				Statusbar::printf("Action aborted");
-			}
+  wHeader = new NC::Window(0, 0, COLS, Actions::HeaderHeight, "",
+                           Config.header_color, NC::Border());
+  if (Config.header_visibility || Config.design == Design::Alternative)
+    wHeader->display();
 
-			if (myScreen == myPlaylist)
-				myPlaylist->enableHighlighting();
-		}
-		catch (MPD::ClientError &e)
-		{
-			Status::handleClientError(e);
-		}
-		catch (MPD::ServerError &e)
-		{
-			Status::handleServerError(e);
-		}
-		catch (std::exception &e)
-		{
-			Statusbar::printf("Unexpected error: %1%", e.what());
-		}
-	}
-	return 0;
+  wFooter =
+      new NC::Window(0, Actions::FooterStartY, COLS, Actions::FooterHeight, "",
+                     Config.statusbar_color, NC::Border());
+  wFooter->setPromptHook(Statusbar::Helpers::mainHook);
+
+  MPRIS::initialize();
+  MPRIS::registerFDCallback(*wFooter);
+
+  // initialize global timer
+  Timer = boost::posix_time::microsec_clock::local_time();
+
+  // initialize global random number generator
+  Global::RNG.seed(std::random_device()());
+
+  // initialize playlist
+  myPlaylist->switchTo();
+
+  // go to startup screen
+  if (Config.startup_screen_type != myScreen->type()) {
+    auto startup_screen = toScreen(Config.startup_screen_type);
+    assert(startup_screen != nullptr);
+    startup_screen->switchTo();
+  }
+
+  // lock current screen and go to the slave one if applicable
+  if (Config.startup_slave_screen_type) {
+    auto slave_screen_type = *Config.startup_slave_screen_type;
+    bool screen_locked = myScreen->lock();
+    if (screen_locked && slave_screen_type != myScreen->type()) {
+      auto slave_screen = toScreen(slave_screen_type);
+      assert(slave_screen != nullptr);
+      slave_screen->switchTo();
+      if (!Config.startup_slave_screen_focus)
+        Actions::get(Actions::Type::MasterScreen).execute();
+    }
+  }
+
+  // local variables
+  bool key_pressed = false;
+  auto input = NC::Key::None;
+  auto connect_attempt = boost::posix_time::from_time_t(0);
+  auto update_environment = static_cast<Actions::UpdateEnvironment &>(
+      Actions::get(Actions::Type::UpdateEnvironment));
+
+  while (!Actions::ExitMainLoop) {
+    try {
+      if (!Mpd.Connected() &&
+          Timer - connect_attempt > boost::posix_time::seconds(1)) {
+        connect_attempt = Timer;
+        // reset local status info
+        Status::clear();
+        // clear mpd callback
+        wFooter->clearFDCallbacksList();
+
+        MPRIS::registerFDCallback(*wFooter);
+
+        try {
+          Mpd.Connect();
+          if (Mpd.Version() < 16) {
+            Mpd.Disconnect();
+            throw MPD::ClientError(MPD_ERROR_STATE,
+                                   "MPD < 0.16.0 is not supported", false);
+          }
+        } catch (MPD::ClientError &e) {
+          Status::handleClientError(e);
+        }
+      }
+
+      if (run_resize_screen) {
+        Actions::resizeScreen(true);
+        run_resize_screen = false;
+      }
+
+      // Process pending MPRIS messages even if fd callbacks are not triggered.
+      MPRIS::process();
+
+      update_environment.run(!key_pressed, key_pressed, false);
+
+      input = readKey(*wFooter);
+      key_pressed = input != NC::Key::None;
+      if (!key_pressed)
+        continue;
+
+      // The reason we want to update timer here is that if the timer is updated
+      // in Status::trace, then Key::read usually blocks for 500ms and if key is
+      // pressed 400ms after Key::read was called, we end up with Timer that is
+      // ~400ms inaccurate. On the other hand, if keys are being pressed, we
+      // don't want to update timer in both Status::trace and here. Therefore we
+      // update timer in Status::trace only if there was no recent input.
+      Timer = boost::posix_time::microsec_clock::local_time();
+
+      try {
+        auto k = Bindings.get(input);
+        [[maybe_unused]] bool executed = std::any_of(
+            k.first, k.second, std::bind(&Binding::execute, ph::_1));
+      } catch (ConversionError &e) {
+        Statusbar::printf("Invalid value: %1%", e.value());
+      } catch (OutOfBounds &e) {
+        Statusbar::printf("Error: %1%", e.errorMessage());
+      } catch (NC::PromptAborted &) {
+        Statusbar::printf("Action aborted");
+      }
+
+      if (myScreen == myPlaylist)
+        myPlaylist->enableHighlighting();
+    } catch (MPD::ClientError &e) {
+      Status::handleClientError(e);
+    } catch (MPD::ServerError &e) {
+      Status::handleServerError(e);
+    } catch (std::exception &e) {
+      Statusbar::printf("Unexpected error: %1%", e.what());
+    }
+  }
+  return 0;
 }


### PR DESCRIPTION
This PR adds native MPRIS2 support to ncmpcpp, so it can be controlled directly via D-Bus clients such as playerctl and consumed by status bars like Waybar without external bridges.

  **What’s included:**
  - New optional MPRIS D-Bus module:
      - src/mpris_dbus.cpp
      - src/mpris_dbus.h
  - Build integration:
      - configure.ac: adds --enable-dbus-mpris and dbus-1 detection
      - src/Makefile.am: adds new source/header
  - Runtime integration in main loop:
      - initialize/shutdown MPRIS
      - process D-Bus events in the main loop
      - register D-Bus fd callback on footer window

  Implemented interfaces:
  - org.mpris.MediaPlayer2
  - org.mpris.MediaPlayer2.Player
  - org.freedesktop.DBus.Properties
  - org.freedesktop.DBus.Introspectable

  Implemented properties/methods/signals:
  - Properties: Get, GetAll, Set
  - Player methods: Play, Pause, PlayPause, Stop, Next, Previous, Seek, SetPosition, OpenUri
  - Signals: PropertiesChanged, Seeked
  - Player properties include:
      - PlaybackStatus, Metadata, Position
      - LoopStatus, Shuffle, Volume, Rate, MinimumRate, MaximumRate
      - CanGoNext, CanGoPrevious, CanPlay, CanPause, CanSeek, CanControl
  - MediaPlayer2 properties include:
      - Identity, DesktopEntry
      - SupportedUriSchemes, SupportedMimeTypes
      - CanQuit, CanRaise, CanSetFullscreen, Fullscreen, HasTrackList

  Behavior notes:
  - Rate is exposed for MPRIS compatibility; only 1.0 is accepted.
  - HasTrackList is false (TrackList interface is not implemented).
  - Metadata includes standard fields like mpris:trackid, mpris:length, xesam:title, xesam:artist, xesam:album, xesam:url.

  **Why?**
  This enables first-class interoperability with the Linux media ecosystem (playerctl, Waybar, other MPRIS consumers) directly from ncmpcpp, without requiring separate MPD MPRIS bridge processes.

Build instructions:
  - Regenerate autotools files: 
         `autoreconf -fi`
  - Configure with native MPRIS enabled: 
        `./configure --enable-dbus-mpris`
  - Build:
        `make -j"$(nproc)"`
  - Optional install:
        `sudo make install`
  - Run:
        `./src/ncmpcpp`

  **Dependencies**
  - dbus-1 (required when --enable-dbus-mpris is used)
  - regular ncmpcpp deps (libmpdclient, ncursesw, boost, etc.)

  **Quick runtime check**
  playerctl -l
  playerctl -p ncmpcpp status

Manual testing:
  - playerctl -l shows ncmpcpp
  - playerctl -p ncmpcpp status
  - playerctl -p ncmpcpp play-pause
  - playerctl -p ncmpcpp next
  - playerctl -p ncmpcpp previous
  - playerctl -p ncmpcpp metadata
  - Waybar mpris module displays and updates state/track info without UnknownProperty errors.
